### PR TITLE
Port all core examples

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,5 +1,4 @@
-// raylib-zig (c) Nikolas Wipper 2020-2024
-
+//! raylib-zig (c) Nikolas Wipper 2025
 const std = @import("std");
 const this = @This();
 const rl = @import("raylib");
@@ -76,6 +75,7 @@ pub fn build(b: *std.Build) !void {
     const raylib = this.getModule(b, target, optimize);
     const raygui = this.gui.getModule(b, target, optimize);
 
+    // TODO: Generate this automatically
     const examples = [_]Program{
         .{
             .name = "raw_stream",

--- a/build.zig
+++ b/build.zig
@@ -294,6 +294,11 @@ pub fn build(b: *std.Build) !void {
             .desc = "Mix 2d and 3d elements",
         },
         .{
+            .name = "window_letterbox",
+            .path = "examples/core/window_letterbox.zig",
+            .desc = "Render to a scaled texture",
+        },
+        .{
             .name = "scissor_test",
             .path = "examples/core/scissor_test.zig",
             .desc = "Scissor mode test",

--- a/build.zig
+++ b/build.zig
@@ -268,6 +268,41 @@ pub fn build(b: *std.Build) !void {
             .path = "examples/models/models_heightmap.zig",
             .desc = "Heightmap loading and drawing",
         },
+        .{
+            .name = "vr_simulator",
+            .path = "examples/core/vr_simulator.zig",
+            .desc = "Vr device simulator",
+        },
+        .{
+            .name = "smooth_pixelperfect",
+            .path = "examples/core/smooth_pixelperfect.zig",
+            .desc = "Smooth Pixel-perfect camera",
+        },
+        .{
+            .name = "window_should_close",
+            .path = "examples/core/window_should_close.zig",
+            .desc = "Ask for confirmation before closing the window",
+        },
+        .{
+            .name = "random_values",
+            .path = "examples/core/random_values.zig",
+            .desc = "Generate a random number every 2 seconds",
+        },
+        .{
+            .name = "world_screen",
+            .path = "examples/core/world_screen.zig",
+            .desc = "Mix 2d and 3d elements",
+        },
+        .{
+            .name = "scissor_test",
+            .path = "examples/core/scissor_test.zig",
+            .desc = "Scissor mode test",
+        },
+        .{
+            .name = "2d_camera_split_screen",
+            .path = "examples/core/2d_camera_split_screen.zig",
+            .desc = "Render a split screen using 2D camera's",
+        },
         // .{
         //     .name = "shaders_basic_lighting",
         //     .path = "examples/shaders/shaders_basic_lighting.zig",

--- a/examples/core/ custom_frame_control.zig
+++ b/examples/core/ custom_frame_control.zig
@@ -1,0 +1,149 @@
+//! # raylib-zig [core] example - Custom frame control
+//!
+//! raylib-zig (c) Nikolas Wipper 2025
+
+// TODO: As SUPPORT_CUSTOM_FRAME_CONTROL is required to be set
+//       the build system should support examples setting config flags.
+//       Until then this example just sits here.
+
+const rl = @import("raylib");
+
+pub fn main() anyerror!void {
+    // Initialization
+    //--------------------------------------------------------------------------------------
+    const screen_width = 800;
+    const screen_height = 450;
+
+    rl.initWindow(screen_width, screen_height, "raylib-zig [core] example - custom frame control");
+    defer rl.closeWindow(); // Close window and OpenGL context
+
+    // Custom timing variables
+    var previous_time: f64 = rl.getTime(); // Previous time measure
+    var current_time: f64 = 0; // Current time measure
+    var update_draw_time: f64 = 0; // Update + Draw time
+    var wait_time: f64 = 0; // Wait time (if target fps required)
+    var delta_time: f32 = 0; // Frame time (Update + Draw + Wait time)
+
+    var time_counter: f32 = 0; // Accumulative time counter (seconds)
+    var position: f32 = 0; // Circle position
+    var pause: bool = false; // Pause control flag
+
+    var target_fps: u32 = 120; // Our initial target fps
+    //--------------------------------------------------------------------------------------
+
+    // Main game loop
+    while (!rl.windowShouldClose()) { // Detect window close button or ESC key
+        // Update
+        //----------------------------------------------------------------------------------
+        rl.pollInputEvents(); // Poll input events (SUPPORT_CUSTOM_FRAME_CONTROL)
+
+        if (rl.isKeyPressed(.space))
+            pause = !pause;
+
+        // change target fps
+        if (rl.isKeyPressed(.up)) {
+            const ov = @addWithOverflow(target_fps, 20);
+            if (ov[1] == 0)
+                target_fps += 20;
+        } else if (rl.isKeyPressed(.down)) {
+            const ov = @subWithOverflow(target_fps, 20);
+            if (ov[1] == 0)
+                target_fps -= 20;
+        }
+
+        if (target_fps < 0)
+            target_fps = 0;
+
+        if (!pause) {
+            position += 200 * delta_time; // We move at 200 pixels per second
+            if (position >= @as(f32, @floatFromInt(rl.getScreenWidth())))
+                position = 0;
+            time_counter += delta_time; // We count time (seconds)
+        }
+        //----------------------------------------------------------------------------------
+
+        // Draw
+        //----------------------------------------------------------------------------------
+        rl.beginDrawing();
+
+        rl.clearBackground(.white);
+
+        for (0..@abs(@divFloor(rl.getScreenWidth(), 200))) |i|
+            rl.drawRectangle(@intCast(200 * i), 0, 1, rl.getScreenHeight(), .sky_blue);
+
+        rl.drawCircle(@intFromFloat(position), @divExact(rl.getScreenHeight(), 2) - 25, 50, .red);
+
+        rl.drawText(
+            rl.textFormat("%03.0f ms", .{time_counter * 1000}),
+            @intFromFloat(position - 40),
+            @divExact(rl.getScreenHeight(), 2) - 100,
+            20,
+            .maroon,
+        );
+        rl.drawText(
+            rl.textFormat("PosX: %03.0f", .{position}),
+            @intFromFloat(position - 50),
+            @divExact(rl.getScreenHeight(), 2) + 40,
+            20,
+            .black,
+        );
+
+        rl.drawText(
+            "Circle is moving at a constant 200 pixels/sec,\nindependently of the frame rate.",
+            10,
+            10,
+            20,
+            .dark_gray,
+        );
+        rl.drawText(
+            "PRESS SPACE to PAUSE MOVEMENT",
+            10,
+            rl.getScreenHeight() - 60,
+            20,
+            .gray,
+        );
+        rl.drawText(
+            "PRESS UP | DOWN to CHANGE TARGET FPS",
+            10,
+            rl.getScreenHeight() - 30,
+            20,
+            .gray,
+        );
+        rl.drawText(
+            rl.textFormat("TARGET FPS: %i", .{target_fps}),
+            rl.getScreenWidth() - 220,
+            10,
+            20,
+            .lime,
+        );
+        rl.drawText(
+            rl.textFormat("CURRENT FPS: %.0f", .{@round(1 / delta_time)}),
+            rl.getScreenWidth() - 220,
+            40,
+            20,
+            .green,
+        );
+
+        rl.endDrawing();
+
+        // NOTE: In case raylib is configured to SUPPORT_CUSTOM_FRAME_CONTROL,
+        // Events polling, screen buffer swap and frame time control must be managed by the user
+
+        rl.swapScreenBuffer(); // Flip the back buffer to screen (front buffer)
+
+        current_time = rl.getTime();
+        update_draw_time = current_time - previous_time;
+
+        if (target_fps > 0) { // We want a fixed frame rate
+            wait_time = (1 / @as(f64, @floatFromInt(target_fps))) - update_draw_time;
+            if (wait_time > 0.0) {
+                rl.waitTime(wait_time);
+                current_time = rl.getTime();
+                delta_time = @floatCast(current_time - previous_time);
+            }
+        } else delta_time = @floatCast(update_draw_time); // Framerate could be variable
+
+        previous_time = current_time;
+        //----------------------------------------------------------------------------------
+    }
+}

--- a/examples/core/2d_camera_split_screen.zig
+++ b/examples/core/2d_camera_split_screen.zig
@@ -1,0 +1,142 @@
+//! # raylib-zig [core] example - 2d camera split screen
+//!
+//! raylib-zig (c) Nikolas Wipper 2025
+
+const rl = @import("raylib");
+
+const PLAYER_SIZE = 40;
+
+pub fn main() anyerror!void {
+    // Initialization
+    //--------------------------------------------------------------------------------------
+    const screen_width = 800;
+    const screen_height = 440;
+
+    rl.initWindow(screen_width, screen_height, "raylib-zig [core] example - 2d camera split screen");
+    defer rl.closeWindow(); // Close window and OpenGL context
+
+    var player1 = rl.Rectangle.init(200, 200, PLAYER_SIZE, PLAYER_SIZE);
+    var player2 = rl.Rectangle.init(250, 200, PLAYER_SIZE, PLAYER_SIZE);
+
+    var camera1: rl.Camera2D = .{
+        .target = rl.Vector2.init(player1.x, player1.y),
+        .offset = rl.Vector2.init(200, 200),
+        .rotation = 0,
+        .zoom = 1,
+    };
+
+    var camera2: rl.Camera2D = .{
+        .target = rl.Vector2.init(player2.x, player2.y),
+        .offset = rl.Vector2.init(200, 200),
+        .rotation = 0,
+        .zoom = 1,
+    };
+
+    const screen_camera1 = try rl.loadRenderTexture(screen_width / 2, screen_height);
+    const screen_camera2 = try rl.loadRenderTexture(screen_width / 2, screen_height);
+    defer rl.unloadRenderTexture(screen_camera1); // Unload render texture
+    defer rl.unloadRenderTexture(screen_camera2); // Unload render texture
+
+    // Build a flipped rectangle the size of the split view to use for drawing later
+    const split_screen_rect = rl.Rectangle.init(
+        0,
+        0,
+        @floatFromInt(screen_camera1.texture.width),
+        @floatFromInt(-screen_camera1.texture.height),
+    );
+
+    rl.setTargetFPS(60); // Set our game to run at 60 frames-per-second
+    //--------------------------------------------------------------------------------------
+
+    // Main game loop
+    while (!rl.windowShouldClose()) { // Detect window close button or ESC key
+        // Update
+        //----------------------------------------------------------------------------------
+
+        if (rl.isKeyDown(.s)) player1.y += 3 else if (rl.isKeyDown(.w)) player1.y -= 3;
+        if (rl.isKeyDown(.d)) player1.x += 3 else if (rl.isKeyDown(.a)) player1.x -= 3;
+
+        if (rl.isKeyDown(.down)) player2.y += 3 else if (rl.isKeyDown(.up)) player2.y -= 3;
+        if (rl.isKeyDown(.right)) player2.x += 3 else if (rl.isKeyDown(.left)) player2.x -= 3;
+
+        camera1.target = rl.Vector2.init(player1.x, player1.y);
+        camera2.target = rl.Vector2.init(player2.x, player2.y);
+        //----------------------------------------------------------------------------------
+
+        // Draw
+        //----------------------------------------------------------------------------------
+        rl.beginTextureMode(screen_camera1);
+        rl.clearBackground(.white);
+
+        rl.beginMode2D(camera1);
+
+        // Draw full scene with first camera
+        drawScene(screen_width, screen_height);
+
+        rl.drawRectangleRec(player1, .red);
+        rl.drawRectangleRec(player2, .blue);
+        rl.endMode2D();
+
+        rl.drawRectangle(0, 0, @divFloor(rl.getScreenWidth(), 2), 30, rl.fade(.white, 0.6));
+        rl.drawText("PLAYER1: W/S/A/D to move", 10, 10, 10, .maroon);
+
+        rl.endTextureMode();
+
+        rl.beginTextureMode(screen_camera2);
+        rl.clearBackground(.white);
+
+        rl.beginMode2D(camera2);
+
+        // Draw full scene with second camera
+        drawScene(screen_width, screen_height);
+
+        rl.drawRectangleRec(player1, .red);
+        rl.drawRectangleRec(player2, .blue);
+
+        rl.endMode2D();
+
+        rl.drawRectangle(0, 0, @divFloor(rl.getScreenWidth(), 2), 30, rl.fade(.white, 0.6));
+        rl.drawText("PLAYER2: UP/DOWN/LEFT/RIGHT to move", 10, 10, 10, .dark_blue);
+
+        rl.endTextureMode();
+
+        // Draw both views render textures to the screen side by side
+        rl.beginDrawing();
+        rl.clearBackground(.black);
+
+        rl.drawTextureRec(screen_camera1.texture, split_screen_rect, rl.Vector2.init(0, 0), .white);
+        rl.drawTextureRec(screen_camera2.texture, split_screen_rect, rl.Vector2.init(screen_width / 2, 0), .white);
+
+        rl.drawRectangle(@divFloor(rl.getScreenWidth(), 2) - 2, 0, 4, rl.getScreenHeight(), .light_gray);
+        rl.endDrawing();
+        //----------------------------------------------------------------------------------
+    }
+}
+
+// NOTE: Using comptime_int makes our code much simpler, however if width and height
+//       are only runtime known this function will need extra work!
+fn drawScene(width: comptime_int, height: comptime_int) void {
+    for (0..width / PLAYER_SIZE + 1) |i|
+        rl.drawLineV(
+            rl.Vector2.init(@floatFromInt(PLAYER_SIZE * i), 0),
+            rl.Vector2.init(@floatFromInt(PLAYER_SIZE * i), height),
+            .light_gray,
+        );
+
+    for (0..height / PLAYER_SIZE + 1) |i|
+        rl.drawLineV(
+            rl.Vector2.init(0, @floatFromInt(PLAYER_SIZE * i)),
+            rl.Vector2.init(width, @floatFromInt(PLAYER_SIZE * i)),
+            .light_gray,
+        );
+
+    for (0..width / PLAYER_SIZE) |i|
+        for (0..height / PLAYER_SIZE) |j|
+            rl.drawText(
+                rl.textFormat("[%i,%i]", .{ i, j }),
+                @intCast(10 + PLAYER_SIZE * i),
+                @intCast(15 + PLAYER_SIZE * j),
+                10,
+                .light_gray,
+            );
+}

--- a/examples/core/3d_camera_mode.zig
+++ b/examples/core/3d_camera_mode.zig
@@ -1,0 +1,59 @@
+//! # raylib-zig [core] example - 3d camera mode
+//!
+//! raylib-zig (c) Nikolas Wipper 2025
+
+const rl = @import("raylib");
+
+pub fn main() anyerror!void {
+    // Initialization
+    //--------------------------------------------------------------------------------------
+    const screen_width = 800;
+    const screen_height = 450;
+
+    rl.initWindow(screen_width, screen_height, "raylib-zig [core] example - 3d camera mode");
+    defer rl.closeWindow(); // Close window and OpenGL context
+
+    // Define the camera to look into our 3d world
+    const camera: rl.Camera3D = .{
+        .position = .init(0, 10, 10), // Camera position
+        .target = .zero(), // Camera looking at point
+        .up = .init(0, 1, 0), // Camera up vector (rotation towards target)
+        .fovy = 45, // Camera field-of-view Y
+        .projection = .perspective, // Camera mode type
+    };
+
+    const cube_position: rl.Vector3 = .init(0, 0, 0);
+
+    rl.setTargetFPS(60); // Set our game to run at 60 frames-per-second
+    //--------------------------------------------------------------------------------------
+
+    // Main game loop
+    while (!rl.windowShouldClose()) { // Detect window close button or ESC key
+        // Update
+        //----------------------------------------------------------------------------------
+        // TODO: Update your variables here
+        //----------------------------------------------------------------------------------
+
+        // Draw
+        //----------------------------------------------------------------------------------
+        rl.beginDrawing();
+
+        rl.clearBackground(.white);
+
+        camera.begin();
+
+        rl.drawCube(cube_position, 2, 2, 2, .red);
+        rl.drawCubeWires(cube_position, 2, 2, 2, .maroon);
+
+        rl.drawGrid(10, 1);
+
+        camera.end();
+
+        rl.drawText("Welcome to the third dimension!", 10, 40, 20, .dark_gray);
+
+        rl.drawFPS(10, 10);
+
+        rl.endDrawing();
+        //----------------------------------------------------------------------------------
+    }
+}

--- a/examples/core/3d_camera_split_screen.zig
+++ b/examples/core/3d_camera_split_screen.zig
@@ -1,0 +1,163 @@
+//! # raylib-zig [core] example - 3d camera split screen
+//!
+//! raylib-zig (c) Nikolas Wipper 2025
+
+const rl = @import("raylib");
+
+pub fn main() anyerror!void {
+    // Initialization
+    //--------------------------------------------------------------------------------------
+    const screen_width = 800;
+    const screen_height = 450;
+
+    rl.initWindow(screen_width, screen_height, "raylib-zig [core] example - 3d camera split screen");
+    defer rl.closeWindow(); // Close window and OpenGL context
+
+    // Setup player 1 camera and screen
+    var camera_player1: rl.Camera = .{
+        .fovy = 45,
+        .up = .init(0, 1, 0),
+        .target = .init(0, 1, 0),
+        .position = .init(0, 1, -3),
+        .projection = .perspective,
+    };
+    const screen_player1 = try rl.loadRenderTexture(screen_width / 2, screen_height);
+    defer rl.unloadRenderTexture(screen_player1); // Unload render texture
+
+    // Setup player two camera and screen
+    var camera_player2: rl.Camera = .{
+        .fovy = 45,
+        .up = .init(0, 1, 0),
+        .target = .init(0, 3, 0),
+        .position = .init(-3, 3, 0),
+        .projection = .perspective,
+    };
+
+    const screen_player2 = try rl.loadRenderTexture(screen_width / 2, screen_height);
+    defer rl.unloadRenderTexture(screen_player2); // Unload render texture
+
+    // Build a flipped rectangle the size of the split view to use for drawing later
+    const split_screen_rect: rl.Rectangle = .init(
+        0,
+        0,
+        @floatFromInt(screen_player1.texture.width),
+        @floatFromInt(-screen_player1.texture.height),
+    );
+
+    // Grid data
+    const count = 5;
+    const spacing: f32 = 4;
+
+    rl.setTargetFPS(60); // Set our game to run at 60 frames-per-second
+    //--------------------------------------------------------------------------------------
+
+    // Main game loop
+    while (!rl.windowShouldClose()) { // Detect window close button or ESC key
+        // Update
+        //----------------------------------------------------------------------------------
+        // If anyone moves this frame, how far will they move based on the time since the last frame
+        // this moves things at 10 world units per second, regardless of the actual FPS
+        const offset_frame = 10 * rl.getFrameTime();
+
+        // Move Player1 forward and backwards (no turning)
+        if (rl.isKeyDown(.w)) {
+            camera_player1.position.z += offset_frame;
+            camera_player1.target.z += offset_frame;
+        } else if (rl.isKeyDown(.s)) {
+            camera_player1.position.z -= offset_frame;
+            camera_player1.target.z -= offset_frame;
+        }
+
+        // Move Player2 forward and backwards (no turning)
+        if (rl.isKeyDown(.up)) {
+            camera_player2.position.x += offset_frame;
+            camera_player2.target.x += offset_frame;
+        } else if (rl.isKeyDown(.down)) {
+            camera_player2.position.x -= offset_frame;
+            camera_player2.target.x -= offset_frame;
+        }
+        //----------------------------------------------------------------------------------
+
+        // Draw
+        //----------------------------------------------------------------------------------
+        // Draw Player1 view to the render texture
+        screen_player1.begin();
+        rl.clearBackground(.sky_blue);
+
+        camera_player1.begin();
+
+        // Draw scene: grid of cube trees on a plane to make a "world"
+        drawScene(count, spacing);
+
+        // Draw a cube at each player's position
+        rl.drawCube(camera_player1.position, 1, 1, 1, .red);
+        rl.drawCube(camera_player2.position, 1, 1, 1, .blue);
+
+        camera_player1.end();
+
+        rl.drawRectangle(0, 0, @divExact(rl.getScreenWidth(), 2), 40, rl.fade(.white, 0.8));
+        rl.drawText("PLAYER1: W/S to move", 10, 10, 20, .maroon);
+
+        screen_player1.end();
+
+        // Draw Player2 view to the render texture
+        screen_player2.begin();
+        rl.clearBackground(.sky_blue);
+
+        camera_player2.begin();
+
+        drawScene(count, spacing);
+
+        // Draw a cube at each player's position
+        rl.drawCube(camera_player1.position, 1, 1, 1, .red);
+        rl.drawCube(camera_player2.position, 1, 1, 1, .blue);
+
+        camera_player2.end();
+
+        rl.drawRectangle(0, 0, @divExact(rl.getScreenWidth(), 2), 40, rl.fade(.white, 0.8));
+        rl.drawText("PLAYER2: UP/DOWN to move", 10, 10, 20, .dark_blue);
+
+        screen_player2.end();
+
+        // Draw both views render textures to the screen side by side
+        rl.beginDrawing();
+        rl.clearBackground(.black);
+
+        rl.drawTextureRec(screen_player1.texture, split_screen_rect, .zero(), .white);
+        rl.drawTextureRec(
+            screen_player2.texture,
+            split_screen_rect,
+            .init(screen_width / 2, 0),
+            .white,
+        );
+
+        rl.drawRectangle(
+            @divExact(rl.getScreenWidth(), 2) - 2,
+            0,
+            4,
+            rl.getScreenHeight(),
+            .light_gray,
+        );
+        rl.endDrawing();
+        //----------------------------------------------------------------------------------
+    }
+}
+
+// NOTE: Using comptime_int makes our code much simpler, however if tree count
+//       is only runtime known this function will need extra work!
+fn drawScene(tree_count: comptime_int, tree_spacing: f32) void {
+    // Simple world plane
+    rl.drawPlane(.zero(), .init(50, 50), .beige);
+
+    // Cube trees
+    var x = -tree_count * tree_spacing;
+    while (x <= tree_count * tree_spacing) {
+        var z = -tree_count * tree_spacing;
+        while (z <= tree_count * tree_spacing) {
+            rl.drawCube(.init(x, 1.5, z), 1, 1, 1, .lime);
+            rl.drawCube(.init(x, 0.5, z), 0.25, 1, 0.25, .brown);
+            z += tree_spacing;
+        }
+        x += tree_spacing;
+    }
+}

--- a/examples/core/input_gestures.zig
+++ b/examples/core/input_gestures.zig
@@ -13,6 +13,7 @@ pub fn main() anyerror!void {
     const screen_height = 450;
 
     rl.initWindow(screen_width, screen_height, "raylib-zig [core] example - input gestures");
+    defer rl.closeWindow(); // Close window and OpenGL context
 
     var touch_position: rl.Vector2 = .zero();
     const touch_area: rl.Rectangle = .init(

--- a/examples/core/input_gestures.zig
+++ b/examples/core/input_gestures.zig
@@ -1,0 +1,124 @@
+//! # raylib-zig [core] example - Input gestures detection
+//!
+//! raylib-zig (c) Nikolas Wipper 2025
+
+const rl = @import("raylib");
+
+const MAX_GESTURE_STRINGS = 20;
+
+pub fn main() anyerror!void {
+    // Initialization
+    //--------------------------------------------------------------------------------------
+    const screen_width = 800;
+    const screen_height = 450;
+
+    rl.initWindow(screen_width, screen_height, "raylib-zig [core] example - input gestures");
+
+    var touch_position: rl.Vector2 = .zero();
+    const touch_area: rl.Rectangle = .init(
+        220,
+        10,
+        screen_width - 230,
+        screen_height - 20,
+    );
+
+    var gestures_count: usize = 0;
+    var gesture_strings: [MAX_GESTURE_STRINGS][:0]const u8 = undefined;
+
+    var current_gesture: rl.Gesture = .none;
+    var last_gesture: rl.Gesture = .none;
+
+    //rl.setGesturesEnabled(.tap); // Enable only some gestures to be detected
+
+    rl.setTargetFPS(60); // Set our game to run at 60 frames-per-second
+    //--------------------------------------------------------------------------------------
+
+    // Main game loop
+    while (!rl.windowShouldClose()) { // Detect window close button or ESC key
+        // Update
+        //----------------------------------------------------------------------------------
+        last_gesture = current_gesture;
+        current_gesture = rl.getGestureDetected();
+        touch_position = rl.getTouchPosition(0);
+
+        if (rl.checkCollisionPointRec(touch_position, touch_area) and (current_gesture != .none)) {
+            if (current_gesture != last_gesture) {
+                // Store gesture string
+                gesture_strings[gestures_count] = switch (current_gesture) {
+                    .tap => "GESTURE TAP",
+                    .doubletap => "GESTURE DOUBLETAP",
+                    .hold => "GESTURE HOLD",
+                    .drag => "GESTURE DRAG",
+                    .swipe_right => "GESTURE SWIPE RIGHT",
+                    .swipe_left => "GESTURE SWIPE LEFT",
+                    .swipe_up => "GESTURE SWIPE UP",
+                    .swipe_down => "GESTURE SWIPE DOWN",
+                    .pinch_in => "GESTURE PINCH IN",
+                    .pinch_out => "GESTURE PINCH OUT",
+                    else => break,
+                };
+
+                gestures_count += 1;
+
+                // Reset gestures strings
+                if (gestures_count >= MAX_GESTURE_STRINGS) {
+                    for (0..MAX_GESTURE_STRINGS) |i| {
+                        gesture_strings[i] = "";
+                    }
+                    gestures_count = 0;
+                }
+            }
+        }
+        //----------------------------------------------------------------------------------
+
+        // Draw
+        //----------------------------------------------------------------------------------
+        rl.beginDrawing();
+
+        rl.clearBackground(.white);
+
+        rl.drawRectangleRec(touch_area, .gray);
+        rl.drawRectangle(225, 15, screen_width - 240, screen_height - 30, .white);
+
+        rl.drawText(
+            "GESTURES TEST AREA",
+            screen_width - 270,
+            screen_height - 40,
+            20,
+            rl.fade(.gray, 0.5),
+        );
+
+        for (0..gestures_count) |i| {
+            if (i % 2 == 0)
+                rl.drawRectangle(10, 30 + @as(i32, @intCast(20 * i)), 200, 20, rl.fade(.light_gray, 0.5))
+            else
+                rl.drawRectangle(10, 30 + @as(i32, @intCast(20 * i)), 200, 20, rl.fade(.light_gray, 0.3));
+
+            if (i < gestures_count - 1)
+                rl.drawText(
+                    gesture_strings[i],
+                    35,
+                    36 + @as(i32, @intCast(20 * i)),
+                    10,
+                    .dark_gray,
+                )
+            else
+                rl.drawText(
+                    gesture_strings[i],
+                    35,
+                    36 + @as(i32, @intCast(20 * i)),
+                    10,
+                    .maroon,
+                );
+        }
+
+        rl.drawRectangleLines(10, 29, 200, screen_height - 50, .gray);
+        rl.drawText("DETECTED GESTURES", 50, 15, 10, .gray);
+
+        if (current_gesture != .none)
+            rl.drawCircleV(touch_position, 30, .maroon);
+
+        rl.endDrawing();
+        //----------------------------------------------------------------------------------
+    }
+}

--- a/examples/core/input_multitouch.zig
+++ b/examples/core/input_multitouch.zig
@@ -1,21 +1,21 @@
-// raylib-zig (c) Nikolas Wipper 2023
+//! # raylib-zig [core] example - Input multitouch
+//!
+//! raylib-zig (c) Nikolas Wipper 2025
 
 const rl = @import("raylib");
+
+const MAX_TOUCH_POINTS = 10;
 
 pub fn main() anyerror!void {
     // Initialization
     //--------------------------------------------------------------------------------------
-    const screenWidth = 800;
-    const screenHeight = 450;
+    const screen_width = 800;
+    const screen_height = 450;
 
-    rl.initWindow(screenWidth, screenHeight, "raylib-zig [core] example - basic window");
+    rl.initWindow(screen_width, screen_height, "raylib-zig [core] example - input multitouch");
     defer rl.closeWindow(); // Close window and OpenGL context
 
-    var ballPosition = rl.Vector2.init(-100, -100);
-    var ballColor = rl.Color.beige;
-
-    var touchCounter: f32 = 0;
-    var touchPosition = rl.Vector2.init(0, 0);
+    var touch_positions: [MAX_TOUCH_POINTS]rl.Vector2 = undefined;
 
     rl.setTargetFPS(60); // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------
@@ -24,66 +24,43 @@ pub fn main() anyerror!void {
     while (!rl.windowShouldClose()) { // Detect window close button or ESC key
         // Update
         //----------------------------------------------------------------------------------
-        ballPosition = rl.getMousePosition();
-
-        ballColor = .beige;
-
-        if (rl.isMouseButtonDown(.left)) {
-            ballColor = .maroon;
-        }
-        if (rl.isMouseButtonDown(.middle)) {
-            ballColor = .lime;
-        }
-        if (rl.isMouseButtonDown(.right)) {
-            ballColor = .dark_blue;
-        }
-
-        if (rl.isMouseButtonPressed(.left)) {
-            touchCounter = 10;
-        }
-        if (rl.isMouseButtonPressed(.middle)) {
-            touchCounter = 10;
-        }
-        if (rl.isMouseButtonPressed(.right)) {
-            touchCounter = 10;
-        }
-
-        if (touchCounter > 0) {
-            touchCounter -= 1;
-        }
+        // Get the touch point count ( how many fingers are touching the screen )
+        const touch_count = rl.getTouchPointCount();
+        // Clamp touch_count and get touch points positions
+        for (0..@min(@as(usize, @intCast(touch_count)), MAX_TOUCH_POINTS)) |i|
+            touch_positions[i] = rl.getTouchPosition(@intCast(i));
         //----------------------------------------------------------------------------------
 
         // Draw
         //----------------------------------------------------------------------------------
         rl.beginDrawing();
-        defer rl.endDrawing();
 
-        rl.clearBackground(.ray_white);
+        rl.clearBackground(.white);
 
-        const nums = [_]i32{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-        for (nums) |i| {
-            touchPosition = rl.getTouchPosition(i); // Get the touch point
-
-            // Make sure point is not (-1,-1) as this means there is no touch for it
-            if ((touchPosition.x >= 0) and (touchPosition.y >= 0)) {
-
+        for (0..@intCast(touch_count)) |i| {
+            // Make sure point is not (0, 0) as this means there is no touch for it
+            if ((touch_positions[i].x > 0) and (touch_positions[i].y > 0)) {
                 // Draw circle and touch index number
-                rl.drawCircleV(touchPosition, 34, .orange);
+                rl.drawCircleV(touch_positions[i], 34, .orange);
                 rl.drawText(
                     rl.textFormat("%d", .{i}),
-                    @as(i32, @intFromFloat(touchPosition.x)) - 10,
-                    @as(i32, @intFromFloat(touchPosition.y)) - 70,
+                    @as(i32, @intFromFloat(touch_positions[i].x)) - 10,
+                    @as(i32, @intFromFloat(touch_positions[i].y)) - 70,
                     40,
                     .black,
                 );
             }
         }
 
-        // Draw the normal mouse location
-        rl.drawCircleV(ballPosition, 30 + (touchCounter * 3), ballColor);
+        rl.drawText(
+            "touch the screen at multiple locations to get multiple balls",
+            10,
+            10,
+            20,
+            .dark_gray,
+        );
 
-        rl.drawText("move ball with mouse and click mouse button to change color", 10, 10, 20, .dark_gray);
-        rl.drawText("touch the screen at multiple locations to get multiple balls", 10, 30, 20, .dark_gray);
+        rl.endDrawing();
         //----------------------------------------------------------------------------------
     }
 }

--- a/examples/core/random_values.zig
+++ b/examples/core/random_values.zig
@@ -1,0 +1,53 @@
+//! # raylib-zig [core] example - Generate random values
+//!
+//! raylib-zig (c) Nikolas Wipper 2025
+
+const rl = @import("raylib");
+
+pub fn main() anyerror!void {
+    // Initialization
+    //--------------------------------------------------------------------------------------
+    const screen_width = 800;
+    const screen_height = 450;
+
+    rl.initWindow(screen_width, screen_height, "raylib-zig [core] example - generate random values");
+    defer rl.closeWindow(); // Close window and OpenGL context
+
+    // Set a custom random seed if desired, by default: "std.time.timestamp()"
+    // rl.setRandomSeed(0xaabbccff);
+
+    // Get a random integer number between -8 and 5 (both included)
+    var rand_value = rl.getRandomValue(-8, 5);
+
+    var frames_counter: u32 = 0;
+
+    rl.setTargetFPS(60); // Set our game to run at 60 frames-per-second
+    //--------------------------------------------------------------------------------------
+
+    // Main game loop
+    while (!rl.windowShouldClose()) { // Detect window close button or ESC key
+        // Update
+        //----------------------------------------------------------------------------------
+        frames_counter += 1;
+
+        // Every two seconds (120 frames) a new random value is generated
+        if (((frames_counter / 120) % 2) == 1) {
+            rand_value = rl.getRandomValue(-8, 5);
+            frames_counter = 0;
+        }
+        //----------------------------------------------------------------------------------
+
+        // Draw
+        //----------------------------------------------------------------------------------
+        rl.beginDrawing();
+
+        rl.clearBackground(.white);
+
+        rl.drawText("Every 2 seconds a new random value is generated:", 130, 100, 20, .maroon);
+
+        rl.drawText(rl.textFormat("%i", .{rand_value}), 360, 180, 80, .light_gray);
+
+        rl.endDrawing();
+        //----------------------------------------------------------------------------------
+    }
+}

--- a/examples/core/scissor_test.zig
+++ b/examples/core/scissor_test.zig
@@ -1,0 +1,61 @@
+//! # raylib-zig [core] example - Scissor test
+//!
+//! raylib-zig (c) Nikolas Wipper 2025
+
+const rl = @import("raylib");
+
+pub fn main() anyerror!void {
+    // Initialization
+    //--------------------------------------------------------------------------------------
+    const screen_width = 800;
+    const screen_height = 450;
+
+    rl.initWindow(screen_width, screen_height, "raylib-zig [core] example - scissor test");
+
+    var scissor_area = rl.Rectangle.init(0, 0, 300, 300);
+    var scissor_mode: bool = true;
+
+    rl.setTargetFPS(60); // Set our game to run at 60 frames-per-second
+    //--------------------------------------------------------------------------------------
+
+    // Main game loop
+    while (!rl.windowShouldClose()) { // Detect window close button or ESC key
+        // Update
+        //----------------------------------------------------------------------------------
+        if (rl.isKeyPressed(.s))
+            scissor_mode = !scissor_mode;
+
+        // Centre the scissor area around the mouse position
+        scissor_area.x = @as(f32, @floatFromInt(rl.getMouseX())) - scissor_area.width / 2;
+        scissor_area.y = @as(f32, @floatFromInt(rl.getMouseY())) - scissor_area.height / 2;
+        //----------------------------------------------------------------------------------
+
+        // Draw
+        //----------------------------------------------------------------------------------
+        rl.beginDrawing();
+
+        rl.clearBackground(.white);
+
+        if (scissor_mode)
+            rl.beginScissorMode(
+                @intFromFloat(scissor_area.x),
+                @intFromFloat(scissor_area.y),
+                @intFromFloat(scissor_area.width),
+                @intFromFloat(scissor_area.height),
+            );
+
+        // Draw full screen rectangle and some text
+        // NOTE: Only part defined by scissor area will be rendered
+        rl.drawRectangle(0, 0, rl.getScreenWidth(), rl.getScreenHeight(), .red);
+        rl.drawText("Move the mouse around to reveal this text!", 190, 200, 20, .light_gray);
+
+        if (scissor_mode)
+            rl.endScissorMode();
+
+        rl.drawRectangleLinesEx(scissor_area, 1, .black);
+        rl.drawText("Press S to toggle scissor test", 10, 10, 20, .black);
+
+        rl.endDrawing();
+        //----------------------------------------------------------------------------------
+    }
+}

--- a/examples/core/smooth_pixelperfect.zig
+++ b/examples/core/smooth_pixelperfect.zig
@@ -1,0 +1,134 @@
+//! # raylib-zig [core] example - Smooth Pixel-perfect camera
+//!
+//! raylib-zig (c) Nikolas Wipper 2025
+
+const rl = @import("raylib");
+
+pub fn main() anyerror!void {
+    // Initialization
+    //--------------------------------------------------------------------------------------
+    const screen_width: usize = 800;
+    const screen_height: usize = 450;
+
+    const virtual_screen_width: f32 = 160;
+    const virtual_screen_height: f32 = 90;
+
+    const virtual_ratio = screen_width / virtual_screen_width;
+
+    rl.initWindow(screen_width, screen_height, "raylib-zig [core] example - smooth pixel-perfect camera");
+    defer rl.closeWindow(); // Close window and OpenGL context
+
+    // Game world camera
+    var world_space_camera: rl.Camera2D = .{
+        .zoom = 1,
+        .offset = undefined,
+        .rotation = undefined,
+        .target = undefined,
+    };
+
+    // Smoothing camera
+    var screen_space_camera: rl.Camera2D = .{
+        .zoom = 1,
+        .offset = undefined,
+        .rotation = undefined,
+        .target = undefined,
+    };
+
+    // This is where we'll draw all our objects.
+    const target: rl.RenderTexture2D = try rl.loadRenderTexture(
+        virtual_screen_width,
+        virtual_screen_height,
+    );
+    defer rl.unloadRenderTexture(target); // Unload render texture
+
+    const rec1 = rl.Rectangle.init(70, 35, 20, 20);
+    const rec2 = rl.Rectangle.init(90, 55, 30, 10);
+    const rec3 = rl.Rectangle.init(80, 65, 15, 25);
+
+    // The target's height is flipped (in the source Rectangle), due to OpenGL reasons
+    const source_rect = rl.Rectangle.init(
+        0,
+        0,
+        @floatFromInt(target.texture.width),
+        @floatFromInt(-target.texture.height),
+    );
+    const dest_rect = rl.Rectangle.init(
+        -virtual_ratio,
+        -virtual_ratio,
+        screen_width + (virtual_ratio * 2),
+        screen_height + (virtual_ratio * 2),
+    );
+
+    const origin = rl.Vector2.init(0, 0);
+
+    var rotation: f32 = 0;
+
+    var camera_x: f32 = 0;
+    var camera_y: f32 = 0;
+
+    rl.setTargetFPS(60);
+    //--------------------------------------------------------------------------------------
+
+    // Main game loop
+    while (!rl.windowShouldClose()) { // Detect window close button or ESC key
+        // Update
+        //----------------------------------------------------------------------------------
+        // Rotate the rectangles, 60 degrees per second
+        rotation += 60 * rl.getFrameTime();
+
+        // Make the camera move to demonstrate the effect
+        const elapsed_time: f32 = @floatCast(rl.getTime());
+        camera_x = (@sin(elapsed_time) * 50) - 10;
+        camera_y = @cos(elapsed_time) * 30;
+
+        // Set the camera's target to the values computed above
+        screen_space_camera.target = rl.Vector2.init(camera_x, camera_y);
+
+        // Round worldSpace coordinates, keep decimals into screenSpace coordinates
+        world_space_camera.target.x = @trunc(screen_space_camera.target.x);
+        screen_space_camera.target.x -= world_space_camera.target.x;
+        screen_space_camera.target.x *= virtual_ratio;
+
+        world_space_camera.target.y = @trunc(screen_space_camera.target.y);
+        screen_space_camera.target.y -= world_space_camera.target.y;
+        screen_space_camera.target.y *= virtual_ratio;
+        //----------------------------------------------------------------------------------
+
+        // Draw
+        //----------------------------------------------------------------------------------
+        rl.beginTextureMode(target);
+        rl.clearBackground(.white);
+
+        rl.beginMode2D(world_space_camera);
+        rl.drawRectanglePro(rec1, origin, rotation, .black);
+        rl.drawRectanglePro(rec2, origin, -rotation, .red);
+        rl.drawRectanglePro(rec3, origin, rotation + 45, .blue);
+        rl.endMode2D();
+        rl.endTextureMode();
+
+        rl.beginDrawing();
+        rl.clearBackground(.red);
+
+        rl.beginMode2D(screen_space_camera);
+        rl.drawTexturePro(target.texture, source_rect, dest_rect, origin, 0, .white);
+        rl.endMode2D();
+
+        rl.drawText(
+            rl.textFormat("Screen resolution: %ix%i", .{ screen_width, screen_height }),
+            10,
+            10,
+            20,
+            .dark_blue,
+        );
+        rl.drawText(
+            rl.textFormat("World resolution: %ix%i", .{ virtual_screen_width, virtual_screen_height }),
+            10,
+            40,
+            20,
+            .dark_green,
+        );
+        rl.drawFPS(rl.getScreenWidth() - 95, 10);
+        rl.endDrawing();
+        //----------------------------------------------------------------------------------
+    }
+}

--- a/examples/core/vr_simulator.zig
+++ b/examples/core/vr_simulator.zig
@@ -1,0 +1,162 @@
+//! # raylib-zig [core] example - VR Simulator (Oculus Rift CV1 parameters)
+//!
+//! raylib-zig (c) Nikolas Wipper 2025
+
+const rl = @import("raylib");
+
+pub fn main() anyerror!void {
+    // Initialization
+    //--------------------------------------------------------------------------------------
+    // NOTE: screen_width/screen_height should match VR device aspect ratio
+    const screen_width = 800;
+    const screen_height = 450;
+
+    rl.initWindow(screen_width, screen_height, "raylib-zig [core] example - vr simulator");
+    defer rl.closeWindow(); // Close window and OpenGL context
+
+    // VR device parameters definition
+    const device: rl.VrDeviceInfo = .{
+        // Oculus Rift CV1 parameters for simulator
+        .hResolution = 2160, // Horizontal resolution in pixels
+        .vResolution = 1200, // Vertical resolution in pixels
+        .hScreenSize = 0.133793, // Horizontal size in meters
+        .vScreenSize = 0.0669, // Vertical size in meters
+        .vScreenCenter = 0.1003465, // NOTE: this value is (h_size + v_size) / 2
+        .eyeToScreenDistance = 0.041, // Distance between eye and display in meters
+        .lensSeparationDistance = 0.07, // Lens separation distance in meters
+        .interpupillaryDistance = 0.07, // IPD (distance between pupils) in meters
+
+        // NOTE: CV1 uses fresnel-hybrid-asymmetric lenses with specific compute shaders
+        // Following parameters are just an approximation to CV1 distortion stereo rendering
+        .lensDistortionValues = .{ 1, 0.22, 0.24, 0 },
+        .chromaAbCorrection = .{ 0.996, -0.004, 1.014, 0 },
+    };
+
+    // Load VR stereo config for VR device parameters (Oculus Rift CV1 parameters)
+    const config: rl.VrStereoConfig = rl.loadVrStereoConfig(device);
+    defer rl.unloadVrStereoConfig(config);
+
+    // Distortion shader (uses device lens distortion and chroma)
+    const distortion = try rl.loadShader(null, "resources/shaders/glsl330/distortion.fs");
+    defer rl.unloadShader(distortion);
+
+    // Update distortion shader with lens and distortion-scale parameters
+    rl.setShaderValue(
+        distortion,
+        rl.getShaderLocation(distortion, "leftLensCenter"),
+        @ptrCast(&config.leftLensCenter),
+        .vec2,
+    );
+    rl.setShaderValue(
+        distortion,
+        rl.getShaderLocation(distortion, "rightLensCenter"),
+        @ptrCast(&config.rightLensCenter),
+        .vec2,
+    );
+    rl.setShaderValue(
+        distortion,
+        rl.getShaderLocation(distortion, "leftScreenCenter"),
+        @ptrCast(&config.leftScreenCenter),
+        .vec2,
+    );
+    rl.setShaderValue(
+        distortion,
+        rl.getShaderLocation(distortion, "rightScreenCenter"),
+        @ptrCast(&config.rightScreenCenter),
+        .vec2,
+    );
+
+    rl.setShaderValue(
+        distortion,
+        rl.getShaderLocation(distortion, "scale"),
+        @ptrCast(&config.scale),
+        .vec2,
+    );
+    rl.setShaderValue(
+        distortion,
+        rl.getShaderLocation(distortion, "scaleIn"),
+        @ptrCast(&config.scaleIn),
+        .vec2,
+    );
+    rl.setShaderValue(
+        distortion,
+        rl.getShaderLocation(distortion, "deviceWarpParam"),
+        @ptrCast(&device.lensDistortionValues),
+        .vec4,
+    );
+    rl.setShaderValue(
+        distortion,
+        rl.getShaderLocation(distortion, "chromaAbParam"),
+        @ptrCast(&device.chromaAbCorrection),
+        .vec4,
+    );
+
+    // Initialize framebuffer for stereo rendering
+    // NOTE: Screen size should match HMD aspect ratio
+    const target: rl.RenderTexture2D = try rl.loadRenderTexture(device.hResolution, device.vResolution);
+    defer rl.unloadRenderTexture(target); // Unload stereo render fb
+
+    // The target's height is flipped (in the source Rectangle), due to OpenGL reasons
+    const source_rect = rl.Rectangle.init(
+        0,
+        0,
+        @floatFromInt(target.texture.width),
+        @floatFromInt(-target.texture.height),
+    );
+    const dest_rect = rl.Rectangle.init(0, 0, screen_width, screen_height);
+
+    // Define the camera to look into our 3d world
+    var camera: rl.Camera = .{
+        .position = rl.Vector3.init(5, 2, 5), // Camera position
+        .target = rl.Vector3.init(0, 2, 0), // Camera looking at point
+        .up = rl.Vector3.init(0, 1, 0), // Camera up vector
+        .fovy = 60, // Camera field-of-view Y
+        .projection = .perspective, // Camera projection type
+    };
+
+    const cube_position = rl.Vector3.init(0, 0, 0);
+
+    rl.disableCursor(); // Limit cursor to relative movement inside the window
+
+    rl.setTargetFPS(60); // Set our game to run at 60 frames-per-second
+    //--------------------------------------------------------------------------------------
+
+    // Main game loop
+    while (!rl.windowShouldClose()) { // Detect window close button or ESC key
+        // Update
+        //----------------------------------------------------------------------------------
+        rl.updateCamera(&camera, .first_person);
+        //----------------------------------------------------------------------------------
+
+        // Draw
+        //----------------------------------------------------------------------------------
+        rl.beginTextureMode(target);
+        rl.clearBackground(.white);
+        rl.beginVrStereoMode(config);
+        rl.beginMode3D(camera);
+
+        rl.drawCube(cube_position, 2, 2, 2, .red);
+        rl.drawCubeWires(cube_position, 2, 2, 2, .maroon);
+        rl.drawGrid(40, 1);
+
+        rl.endMode3D();
+        rl.endVrStereoMode();
+        rl.endTextureMode();
+
+        rl.beginDrawing();
+        rl.clearBackground(.white);
+        rl.beginShaderMode(distortion);
+        rl.drawTexturePro(
+            target.texture,
+            source_rect,
+            dest_rect,
+            rl.Vector2.init(0, 0),
+            0,
+            .white,
+        );
+        rl.endShaderMode();
+        rl.drawFPS(10, 10);
+        rl.endDrawing();
+        //----------------------------------------------------------------------------------
+    }
+}

--- a/examples/core/window_letterbox.zig
+++ b/examples/core/window_letterbox.zig
@@ -1,0 +1,127 @@
+const rl = @import("raylib");
+
+//------------------------------------------------------------------------------------
+// Program main entry point
+//------------------------------------------------------------------------------------
+pub fn main() !void {
+    const windowWidth = 800;
+    const windowHeight = 450;
+
+    const gameScreenWidth = 640;
+    const gameScreenHeight = 480;
+
+    // Enable config flags for resizable window and vertical synchro
+    rl.setConfigFlags(.{ .window_resizable = true, .vsync_hint = true });
+
+    rl.initWindow(windowWidth, windowHeight, "raylib [core] example - window scale letterbox");
+    defer rl.closeWindow(); // Close window and OpenGL context
+
+    rl.setWindowMinSize(320, 240);
+
+    // Render texture initialization, used to hold the rendering result so we can easily resize it
+    const target = try rl.loadRenderTexture(gameScreenWidth, gameScreenHeight);
+    defer rl.unloadRenderTexture(target); // Unload render texture
+    rl.setTextureFilter(target.texture, .bilinear); // Texture scale filter to use
+
+    var colors: [10]rl.Color = undefined;
+    for (0..10) |i| {
+        colors[i] = .init(
+            @intCast(rl.getRandomValue(100, 250)),
+            @intCast(rl.getRandomValue(50, 150)),
+            @intCast(rl.getRandomValue(10, 100)),
+            255,
+        );
+    }
+
+    rl.setTargetFPS(60); // Set our game to run at 60 frames-per-second
+    //--------------------------------------------------------------------------------------
+
+    // Main game loop
+    while (!rl.windowShouldClose()) // Detect window close button or ESC key
+    {
+        // Update
+        //----------------------------------------------------------------------------------
+        // Compute required framebuffer scaling
+        const scale = @min(
+            @divFloor(rl.getScreenWidth(), gameScreenWidth),
+            @divFloor(rl.getScreenHeight(), gameScreenHeight),
+        );
+
+        if (rl.isKeyPressed(.space)) {
+            // Recalculate random colors for the bars
+            for (0..10) |i| {
+                colors[i] = .init(
+                    @intCast(rl.getRandomValue(100, 250)),
+                    @intCast(rl.getRandomValue(50, 150)),
+                    @intCast(rl.getRandomValue(10, 100)),
+                    255,
+                );
+            }
+        }
+
+        // Update virtual mouse (clamped mouse value behind game screen)
+        const mouse = rl.getMousePosition();
+        var virtualMouse: rl.Vector2 = .init(0, 0);
+        virtualMouse.x = (mouse.x - @as(f32, @floatFromInt(rl.getScreenWidth() - (gameScreenWidth * scale))) * 0.5) / @as(f32, @floatFromInt(scale));
+        virtualMouse.y = (mouse.y - @as(f32, @floatFromInt(rl.getScreenHeight() - (gameScreenHeight * scale))) * 0.5) / @as(f32, @floatFromInt(scale));
+        virtualMouse = rl.math.vector2Clamp(virtualMouse, .init(0, 0), .init(gameScreenWidth, gameScreenHeight));
+
+        // Apply the same transformation as the virtual mouse to the real mouse (i.e. to work with raygui)
+        //SetMouseOffset(-(GetScreenWidth() - (gameScreenWidth*scale))*0.5f, -(GetScreenHeight() - (gameScreenHeight*scale))*0.5f);
+        //SetMouseScale(1/scale, 1/scale);
+        //----------------------------------------------------------------------------------
+
+        // Draw
+        //----------------------------------------------------------------------------------
+        // Draw everything in the render texture, note this will not be rendered on screen, yet
+        {
+            rl.beginTextureMode(target);
+            defer rl.endTextureMode();
+
+            rl.clearBackground(.white); // Clear render texture background color
+
+            for (0..10) |i| {
+                const offset = @as(i32, @intCast(i));
+
+                rl.drawRectangle(
+                    0,
+                    (gameScreenHeight / 10) * offset,
+                    gameScreenWidth,
+                    gameScreenHeight / 10,
+                    colors[i],
+                );
+            }
+
+            rl.drawText("If executed inside a window,\nyou can resize the window,\nand see the screen scaling!", 10, 25, 20, .white);
+            rl.drawText(rl.textFormat("Default Mouse: [%i , %i]", .{
+                @as(i32, @intFromFloat(mouse.x)),
+                @as(i32, @intFromFloat(mouse.y)),
+            }), 350, 25, 20, .green);
+            rl.drawText(rl.textFormat("Virtual Mouse: [%i , %i]", .{
+                @as(i32, @intFromFloat(virtualMouse.x)),
+                @as(i32, @intFromFloat(virtualMouse.y)),
+            }), 350, 55, 20, .yellow);
+        }
+
+        rl.beginDrawing();
+        defer rl.endDrawing();
+
+        rl.clearBackground(.black); // Clear screen background
+
+        // Draw render texture to screen, properly scaled
+        rl.drawTexturePro(
+            target.texture,
+            .init(0.0, 0.0, @floatFromInt(target.texture.width), @floatFromInt(-target.texture.height)),
+            .init(
+                @as(f32, @floatFromInt(rl.getScreenWidth() - (gameScreenWidth * scale))) * 0.5,
+                @as(f32, @floatFromInt(rl.getScreenHeight() - (gameScreenHeight * scale))) * 0.5,
+                @floatFromInt(gameScreenWidth * scale),
+                @floatFromInt(gameScreenHeight * scale),
+            ),
+            .init(0, 0),
+            0,
+            .white,
+        );
+        //--------------------------------------------------------------------------------------
+    }
+}

--- a/examples/core/window_should_close.zig
+++ b/examples/core/window_should_close.zig
@@ -1,0 +1,70 @@
+//! # raylib-zig [core] example - Window should close
+//!
+//! raylib-zig (c) Nikolas Wipper 2025
+
+const rl = @import("raylib");
+
+pub fn main() anyerror!void {
+    // Initialization
+    //--------------------------------------------------------------------------------------
+    const screen_width = 800;
+    const screen_height = 450;
+
+    rl.initWindow(screen_width, screen_height, "raylib-zig [core] example - window should close");
+    defer rl.closeWindow(); // Close window and OpenGL context
+
+    // Disable KEY_ESCAPE to close window, the window's "X-button" still works
+    rl.setExitKey(.null);
+
+    var exit_window_requested: bool = false; // Flag to request window to exit
+    var exit_window: bool = false; // Flag to set window to exit
+
+    rl.setTargetFPS(60); // Set our game to run at 60 frames-per-second
+    //--------------------------------------------------------------------------------------
+
+    // Main game loop
+    while (!exit_window) { // Detect window close button or ESC key
+        // Update
+        //----------------------------------------------------------------------------------
+        // Detect if "X-button" or KEY_ESCAPE have been pressed to close window
+        if (rl.windowShouldClose() or rl.isKeyPressed(.escape))
+            exit_window_requested = true;
+
+        if (exit_window_requested) {
+            // A request for close window has been issued, we can save data before closing
+            // or just show a message asking for confirmation
+
+            if (rl.isKeyPressed(.y))
+                exit_window = true
+            else if (rl.isKeyPressed(.n))
+                exit_window_requested = false;
+        }
+        //----------------------------------------------------------------------------------
+
+        // Draw
+        //----------------------------------------------------------------------------------
+        rl.beginDrawing();
+
+        rl.clearBackground(.white);
+
+        if (exit_window_requested) {
+            rl.drawRectangle(0, 100, screen_width, 200, .black);
+            rl.drawText(
+                "Are you sure you want to exit program? [Y/N]",
+                40,
+                180,
+                30,
+                .white,
+            );
+        } else rl.drawText(
+            "Try to close the window to get confirmation message!",
+            120,
+            200,
+            20,
+            .light_gray,
+        );
+
+        rl.endDrawing();
+        //----------------------------------------------------------------------------------
+    }
+}

--- a/examples/core/world_screen.zig
+++ b/examples/core/world_screen.zig
@@ -1,0 +1,96 @@
+//! # raylib-zig [core] examples - World to screen
+//!
+//! raylib-zig (c) Nikolas Wipper 2025
+
+const rl = @import("raylib");
+
+pub fn main() anyerror!void {
+    // Initialization
+    //--------------------------------------------------------------------------------------
+    const screen_width: usize = 800;
+    const screen_height: usize = 450;
+
+    rl.initWindow(screen_width, screen_height, "raylib-zig [core] example - world screen");
+    defer rl.closeWindow(); // Close window and OpenGL context
+
+    // Define the camera to look into our 3d world
+    var camera: rl.Camera = .{
+        .position = rl.Vector3.init(10, 10, 10), // Camera position
+        .target = rl.Vector3.init(0, 0, 0), // Camera looking at point
+        .up = rl.Vector3.init(0, 1, 0), // Camera up vector (rotation towards target)
+        .fovy = 45, // Camera field-of-view Y
+        .projection = .perspective, // Camera projection type
+    };
+
+    const cube_position = rl.Vector3.init(0, 0, 0);
+    var cube_screen_position = rl.Vector2.init(0, 0);
+
+    rl.disableCursor(); // Limit cursor to relative movement inside the window
+
+    rl.setTargetFPS(60); // Set our game to run at 60 frames-per-second
+    //--------------------------------------------------------------------------------------
+
+    // Main game loop
+    while (!rl.windowShouldClose()) { // Detect window close button or ESC key
+        // Update
+        //----------------------------------------------------------------------------------
+        rl.updateCamera(&camera, .third_person);
+
+        // Calculate cube screen space position (with a little offset to be in top)
+        cube_screen_position = rl.getWorldToScreen(
+            rl.Vector3.init(cube_position.x, cube_position.y + 2.5, cube_position.z),
+            camera,
+        );
+        //----------------------------------------------------------------------------------
+
+        // Draw
+        //----------------------------------------------------------------------------------
+        rl.beginDrawing();
+
+        rl.clearBackground(.white);
+
+        rl.beginMode3D(camera);
+
+        rl.drawCube(cube_position, 2, 2, 2, .red);
+        rl.drawCubeWires(cube_position, 2, 2, 2, .maroon);
+
+        rl.drawGrid(10, 1);
+
+        rl.endMode3D();
+
+        rl.drawText(
+            "Enemy: 100 / 100",
+            @as(
+                i32,
+                @intFromFloat(cube_screen_position.x),
+            ) - @divFloor(rl.measureText("Enemy: 100/100", 20), 2),
+            @as(
+                i32,
+                @intFromFloat(cube_screen_position.y),
+            ),
+            20,
+            .black,
+        );
+
+        rl.drawText(
+            rl.textFormat("Cube position in screen space coordinates: [%i, %i]", .{
+                @as(i32, @intFromFloat(cube_screen_position.x)),
+                @as(i32, @intFromFloat(cube_screen_position.y)),
+            }),
+            10,
+            10,
+            20,
+            .lime,
+        );
+        rl.drawText(
+            "Text 2d should be always on top of the cube",
+            10,
+            40,
+            20,
+            .gray,
+        );
+
+        rl.endDrawing();
+        //----------------------------------------------------------------------------------
+    }
+}

--- a/resources/shaders/glsl330/distortion.fs
+++ b/resources/shaders/glsl330/distortion.fs
@@ -1,0 +1,53 @@
+#version 330
+
+// Input vertex attributes (from vertex shader)
+in vec2 fragTexCoord;
+in vec4 fragColor;
+
+// Input uniform values
+uniform sampler2D texture0;
+uniform vec4 colDiffuse;
+
+// Output fragment color
+out vec4 finalColor;
+
+// NOTE: Add your custom variables here
+uniform vec2 leftLensCenter = vec2(0.288, 0.5);
+uniform vec2 rightLensCenter = vec2(0.712, 0.5);
+uniform vec2 leftScreenCenter = vec2(0.25, 0.5);
+uniform vec2 rightScreenCenter = vec2(0.75, 0.5);
+uniform vec2 scale = vec2(0.25, 0.45);
+uniform vec2 scaleIn = vec2(4, 2.2222);
+uniform vec4 deviceWarpParam = vec4(1, 0.22, 0.24, 0);
+uniform vec4 chromaAbParam = vec4(0.996, -0.004, 1.014, 0.0);
+
+void main()
+{
+    // Compute lens distortion
+    vec2 lensCenter = fragTexCoord.x < 0.5? leftLensCenter : rightLensCenter;
+    vec2 screenCenter = fragTexCoord.x < 0.5? leftScreenCenter : rightScreenCenter;
+    vec2 theta = (fragTexCoord - lensCenter)*scaleIn;
+    float rSq = theta.x*theta.x + theta.y*theta.y;
+    vec2 theta1 = theta*(deviceWarpParam.x + deviceWarpParam.y*rSq + deviceWarpParam.z*rSq*rSq + deviceWarpParam.w*rSq*rSq*rSq);
+    vec2 thetaBlue = theta1*(chromaAbParam.z + chromaAbParam.w*rSq);
+    vec2 tcBlue = lensCenter + scale*thetaBlue;
+
+    if (any(bvec2(clamp(tcBlue, screenCenter - vec2(0.25, 0.5), screenCenter + vec2(0.25, 0.5)) - tcBlue)))
+    {
+        // Set black fragment for everything outside the lens border
+        finalColor = vec4(0.0, 0.0, 0.0, 1.0);
+    }
+    else
+    {
+        // Compute color chroma aberration
+        float blue = texture(texture0, tcBlue).b;
+        vec2 tcGreen = lensCenter + scale*theta1;
+        float green = texture(texture0, tcGreen).g;
+
+        vec2 thetaRed = theta1*(chromaAbParam.x + chromaAbParam.y*rSq);
+        vec2 tcRed = lensCenter + scale*thetaRed;
+
+        float red = texture(texture0, tcRed).r;
+        finalColor = vec4(red, green, blue, 1.0);
+    }
+}


### PR DESCRIPTION
> [!NOTE]  
> This is a draft PR that is still being worked on!

A start on #200, porting all core Raylib examples. These examples are mostly 1:1; however, some are _slightly_ different, favoring a more idiomatic Zig solution, thus also making the examples more scaleable to a raylib-zig project.

### core
- [x] 2d_camera_platformer (see #222)
- [x] 2d_camera_split_screen
- [x] 3d_camera_mode
- [x] 3d_camera_split_screen
- [ ] automation_events
- [x] custom_frame_control
- [ ] custom_logging
- [ ] drop_files
- [ ] input_gamepad
- [x] input_gestures
- [x] input_multitouch
- [ ] loading_thread
- [x] random_values
- [x] scissor_test
- [x] smooth_pixelperfect
- [ ] storage_values
- [x] vr_simulator
- [x] window_letterbox
- [x] window_should_close
- [x] world_screen