### PR TITLE
Add Shapes examples

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -270,6 +270,11 @@ pub fn build(b: *std.Build) !void {
             .desc = "Renders a spline",
         },
         .{
+            .name = "top_down_lights",
+            .path = "examples/shapes/top_down_lights.zig",
+            .desc = "Renders a sceen with shadows and a top down persepective",
+        },
+        .{
             .name = "sprite_anim",
             .path = "examples/textures/sprite_anim.zig",
             .desc = "Animate a sprite",

--- a/build.zig
+++ b/build.zig
@@ -240,6 +240,11 @@ pub fn build(b: *std.Build) !void {
             .desc = "Renders a ball that demonstrates various easing functions",
         },
         .{
+            .name = "easings_box_anim",
+            .path = "examples/shapes/easings_box_anim.zig",
+            .desc = "Renders a box that demonstrates various easing functions",
+        },
+        .{
             .name = "following_eyes",
             .path = "examples/shapes/following_eyes.zig",
             .desc = "Renders eyes that follow mouse movement",

--- a/build.zig
+++ b/build.zig
@@ -235,6 +235,11 @@ pub fn build(b: *std.Build) !void {
             .desc = "Dynaically renders a ring using raygui",
         },
         .{
+            .name = "easings_ball_anim",
+            .path = "examples/shapes/easings_ball_anim.zig",
+            .desc = "Renders a ball that demonstrates various easing functions",
+        },
+        .{
             .name = "following_eyes",
             .path = "examples/shapes/following_eyes.zig",
             .desc = "Renders eyes that follow mouse movement",

--- a/build.zig
+++ b/build.zig
@@ -265,6 +265,11 @@ pub fn build(b: *std.Build) !void {
             .desc = "Renders a resizable rectangle",
         },
         .{
+            .name = "splines_drawing",
+            .path = "examples/shapes/splines_drawing.zig",
+            .desc = "Renders a spline",
+        },
+        .{
             .name = "sprite_anim",
             .path = "examples/textures/sprite_anim.zig",
             .desc = "Animate a sprite",

--- a/build.zig
+++ b/build.zig
@@ -245,6 +245,11 @@ pub fn build(b: *std.Build) !void {
             .desc = "Renders a box that demonstrates various easing functions",
         },
         .{
+            .name = "easings_rectangle_array",
+            .path = "examples/shapes/easings_rectangle_array.zig",
+            .desc = "Renders a box that demonstrates various easing functions",
+        },
+        .{
             .name = "following_eyes",
             .path = "examples/shapes/following_eyes.zig",
             .desc = "Renders eyes that follow mouse movement",

--- a/examples/shapes/easings_ball_anim.zig
+++ b/examples/shapes/easings_ball_anim.zig
@@ -1,0 +1,86 @@
+const rl = @import("raylib");
+const reasings = @import("reasings.zig");
+
+//------------------------------------------------------------------------------------
+// Program main entry point
+//------------------------------------------------------------------------------------
+pub fn main() anyerror!void {
+    // Initialization
+    //--------------------------------------------------------------------------------------
+    const screenWidth = 800;
+    const screenHeight = 450;
+
+    rl.initWindow(screenWidth, screenHeight, "raylib [shapes] example - easings ball anim");
+    defer rl.closeWindow(); // Defer closing window and OpenGL context
+
+    // Ball variable value to be animated with easings
+    var ballPositionX: i32 = -100;
+    var ballRadius: f32 = 20;
+    var ballAlpha: f32 = 0;
+
+    var state: i32 = 0;
+    var framesCounter: i32 = 0;
+
+    rl.setTargetFPS(60); // Set our game to run at 60 frames-per-second
+    //--------------------------------------------------------------------------------------
+
+    // Main game loop
+    while (!rl.windowShouldClose()) // Detect window close button or ESC key
+    {
+        // Update
+        //----------------------------------------------------------------------------------
+        switch (state) {
+            0 => { // Move ball position X with easing
+                framesCounter += 1;
+                ballPositionX = @intFromFloat(reasings.elasticOut(@floatFromInt(framesCounter), -100, @as(f32, @floatFromInt(screenWidth)) / 2 + 100, 120));
+
+                if (framesCounter >= 120) {
+                    framesCounter = 0;
+                    state = 1;
+                }
+            },
+            1 => { // Increase ball radius with easing
+                framesCounter += 1;
+                ballRadius = reasings.elasticIn(@floatFromInt(framesCounter), 20, 500, 200);
+
+                if (framesCounter >= 200) {
+                    framesCounter = 0;
+                    state = 2;
+                }
+            },
+            2 => { // Change ball alpha with easing (background color blending)
+                framesCounter += 1;
+                ballAlpha = reasings.cubicOut(@floatFromInt(framesCounter), 0.0, 1.0, 200);
+                if (framesCounter >= 200) {
+                    framesCounter = 0;
+                    state = 3;
+                }
+            },
+            3 => { // Reset state to play again
+                if (rl.isKeyPressed(.enter)) {
+                    ballPositionX = -100;
+                    ballRadius = 20;
+                    ballAlpha = 0.0;
+                    state = 0;
+                }
+            },
+            else => unreachable,
+        }
+
+        if (rl.isKeyPressed(.r)) framesCounter = 0;
+        //----------------------------------------------------------------------------------
+        // Draw
+        //----------------------------------------------------------------------------------
+        rl.beginDrawing();
+        defer rl.endDrawing();
+
+        rl.clearBackground(.ray_white);
+
+        if (state >= 2) rl.drawRectangle(0, 0, screenWidth, screenHeight, .green);
+        rl.drawCircle(ballPositionX, 200, ballRadius, .fade(.red, 1.0 - ballAlpha));
+
+        if (state == 3) rl.drawText("PRESS [ENTER] TO PLAY AGAIN!", 240, 200, 20, .black);
+
+        //----------------------------------------------------------------------------------
+    }
+}

--- a/examples/shapes/easings_box_anim.zig
+++ b/examples/shapes/easings_box_anim.zig
@@ -1,0 +1,127 @@
+const rl = @import("raylib");
+const reasing = @import("reasings.zig");
+
+//------------------------------------------------------------------------------------
+// Program main entry point
+//------------------------------------------------------------------------------------
+pub fn main() anyerror!void {
+    // Initialization
+    //--------------------------------------------------------------------------------------
+    const screenWidth = 800;
+    const screenHeight = 450;
+
+    rl.initWindow(screenWidth, screenHeight, "raylib [shapes] example - easings box anim");
+    defer rl.closeWindow();
+
+    // Box variables to be animated with easings
+    var rec: rl.Rectangle = rl.Rectangle{
+        .x = @as(f32, @floatFromInt(rl.getScreenWidth())) / 2.0,
+        .y = -100,
+        .height = 100,
+        .width = 100,
+    };
+    var rotation: f32 = 0.0;
+    var alpha: f32 = 1.0;
+
+    var state: i32 = 0;
+    var framesCounter: i32 = 0;
+
+    rl.setTargetFPS(60); // Set our game to run at 60 frames-per-second
+    //--------------------------------------------------------------------------------------
+
+    // Main game loop
+    while (!rl.windowShouldClose()) // Detect window close button or ESC key
+    {
+        // Update
+        //----------------------------------------------------------------------------------
+        switch (state) {
+            // Move box down to center of screen
+            0 => {
+                framesCounter += 1;
+
+                // NOTE: Remember that 3rd parameter of easing function refers to
+                // desired value variation, do not confuse it with expected final value!
+                rec.y = reasing.elasticOut(@floatFromInt(framesCounter), -100, @as(f32, @floatFromInt(rl.getScreenHeight())) / 2.0 + 100, 120);
+
+                if (framesCounter >= 120) {
+                    framesCounter = 0;
+                    state = 1;
+                }
+            },
+            // Scale box to an horizontal bar
+            1 => {
+                framesCounter += 1;
+                rec.height = reasing.bounceOut(@floatFromInt(framesCounter), 100, -90, 120);
+                rec.width = reasing.bounceOut(@floatFromInt(framesCounter), 100, @floatFromInt(rl.getScreenWidth()), 120);
+
+                if (framesCounter >= 120) {
+                    framesCounter = 0;
+                    state = 2;
+                }
+            },
+            // Rotate horizontal bar rectangle
+            2 => {
+                framesCounter += 1;
+                rotation = reasing.quadOut(@floatFromInt(framesCounter), 0.0, 270.0, 240);
+
+                if (framesCounter >= 240) {
+                    framesCounter = 0;
+                    state = 3;
+                }
+            },
+            // Increase bar size to fill all screen
+            3 => {
+                framesCounter += 1;
+                rec.height = reasing.circOut(@floatFromInt(framesCounter), 10, @floatFromInt(rl.getScreenWidth()), 120);
+
+                if (framesCounter >= 120) {
+                    framesCounter = 0;
+                    state = 4;
+                }
+            },
+            // Fade out animation
+            4 => {
+                framesCounter += 1;
+                alpha = reasing.sineOut(@floatFromInt(framesCounter), 1.0, -1.0, 160);
+
+                if (framesCounter >= 160) {
+                    framesCounter = 0;
+                    state = 5;
+                }
+            },
+            5 => {},
+            else => unreachable,
+        }
+
+        // Reset animation at any moment
+        if (rl.isKeyPressed(.space)) {
+            rec = rl.Rectangle{
+                .x = @as(f32, @floatFromInt(rl.getScreenWidth())) / 2.0,
+                .y = -100,
+                .height = 100,
+                .width = 100,
+            };
+            rotation = 0.0;
+            alpha = 1.0;
+            state = 0;
+            framesCounter = 0;
+        }
+        //----------------------------------------------------------------------------------
+
+        // Draw
+        //----------------------------------------------------------------------------------
+        rl.beginDrawing();
+        defer rl.endDrawing();
+
+        rl.clearBackground(.ray_white);
+
+        rl.drawRectanglePro(rec, rl.Vector2{
+            .x = rec.width / 2,
+            .y = rec.height / 2,
+        }, rotation, .fade(.black, alpha));
+
+        rl.drawText("PRESS [SPACE] TO RESET BOX ANIMATION!", 10, rl.getScreenHeight() - 25, 20, .light_gray);
+
+        //----------------------------------------------------------------------------------
+    }
+}

--- a/examples/shapes/easings_rectangle_array.zig
+++ b/examples/shapes/easings_rectangle_array.zig
@@ -1,0 +1,91 @@
+const rl = @import("raylib");
+const reasings = @import("reasings.zig");
+
+const RECS_WIDTH = 50;
+const RECS_HEIGHT = 50;
+const SCREEN_WIDTH = 800;
+const SCREEN_HEIGHT = 450;
+
+const MAX_RECS_X = SCREEN_WIDTH / RECS_WIDTH;
+const MAX_RECS_Y = SCREEN_HEIGHT / RECS_HEIGHT;
+
+const PLAY_TIME_IN_FRAMES = 240; // At 60 fps = 4 seconds
+
+//------------------------------------------------------------------------------------
+// Program main entry point
+//------------------------------------------------------------------------------------
+pub fn main() anyerror!void {
+    // Initialization
+    //--------------------------------------------------------------------------------------
+
+    rl.initWindow(SCREEN_WIDTH, SCREEN_HEIGHT, "raylib [shapes] example - easings rectangle array");
+    defer rl.closeWindow(); // Close window and OpenGL context
+
+    var recs: [MAX_RECS_X * MAX_RECS_Y]rl.Rectangle = undefined;
+
+    for (0..MAX_RECS_Y) |y| {
+        for (0..MAX_RECS_X) |x| {
+            recs[y * MAX_RECS_X + x].x = RECS_WIDTH / 2.0 + RECS_WIDTH * @as(f32, @floatFromInt(x));
+            recs[y * MAX_RECS_X + x].y = RECS_HEIGHT / 2.0 + RECS_HEIGHT * @as(f32, @floatFromInt(y));
+            recs[y * MAX_RECS_X + x].width = RECS_WIDTH;
+            recs[y * MAX_RECS_X + x].height = RECS_HEIGHT;
+        }
+    }
+
+    var rotation: f32 = 0.0;
+    var framesCounter: i32 = 0;
+    var state: i32 = 0; // Rectangles animation state: 0-Playing, 1-Finished
+
+    rl.setTargetFPS(60); // Set our game to run at 60 frames-per-second
+    //--------------------------------------------------------------------------------------
+
+    // Main game loop
+    while (!rl.windowShouldClose()) // Detect window close button or ESC key
+    {
+        // Update
+        //----------------------------------------------------------------------------------
+        if (state == 0) {
+            framesCounter += 1;
+
+            for (&recs) |*rec| {
+                rec.height = reasings.circOut(@floatFromInt(framesCounter), RECS_HEIGHT, -RECS_HEIGHT, PLAY_TIME_IN_FRAMES);
+                rec.width = reasings.circOut(@floatFromInt(framesCounter), RECS_WIDTH, -RECS_WIDTH, PLAY_TIME_IN_FRAMES);
+
+                if (rec.height < 0) rec.height = 0;
+                if (rec.width < 0) rec.width = 0;
+
+                if ((rec.height == 0) and (rec.width == 0)) state = 1; // Finish playing
+
+                rotation = reasings.linearIn(@floatFromInt(framesCounter), 0.0, 360.0, PLAY_TIME_IN_FRAMES);
+            }
+        } else if ((state == 1) and rl.isKeyPressed(.space)) {
+            // When animation has finished, press space to restart
+            framesCounter = 0;
+
+            for (&recs) |*rec| {
+                rec.height = RECS_HEIGHT;
+                rec.width = RECS_WIDTH;
+            }
+
+            state = 0;
+        }
+        //----------------------------------------------------------------------------------
+
+        // Draw
+        //----------------------------------------------------------------------------------
+        rl.beginDrawing();
+        defer rl.endDrawing();
+
+        rl.clearBackground(.ray_white);
+        if (state == 0) {
+            for (recs) |rec| {
+                rl.drawRectanglePro(rec, rl.Vector2{
+                    .x = rec.width / 2,
+                    .y = rec.height / 2,
+                }, rotation, .red);
+            }
+        } else if (state == 1) rl.drawText("PRESS [SPACE] TO PLAY AGAIN!", 240, 200, 20, .gray);
+
+        //----------------------------------------------------------------------------------
+    }
+}

--- a/examples/shapes/reasings.zig
+++ b/examples/shapes/reasings.zig
@@ -1,0 +1,192 @@
+const math = @import("std").math;
+
+// Linear Easing functions
+pub fn linearNone(t: f32, b: f32, c: f32, d: f32) f32 {
+    return (c * t / d + b);
+}
+pub fn linearIn(t: f32, b: f32, c: f32, d: f32) f32 {
+    return (c * t / d + b);
+}
+pub fn linearOut(t: f32, b: f32, c: f32, d: f32) f32 {
+    return (c * t / d + b);
+}
+pub fn linearInOut(t: f32, b: f32, c: f32, d: f32) f32 {
+    return (c * t / d + b);
+}
+
+pub fn sineIn(t: f32, b: f32, c: f32, d: f32) f32 {
+    return (-c * math.cos(t / d * (math.pi / 2.0)) + c + b);
+}
+pub fn sineOut(t: f32, b: f32, c: f32, d: f32) f32 {
+    return (c * math.sin(t / d * (math.pi / 2.0)) + b);
+}
+pub fn sineInOut(t: f32, b: f32, c: f32, d: f32) f32 {
+    return (-c / 2.0 * (math.cos(math.pi * t / d) - 1.0) + b);
+}
+
+// Circular Easing functions
+pub fn circIn(t: f32, b: f32, c: f32, d: f32) f32 {
+    const postFix = t / d;
+    return (-c * (math.sqrt(1.0 - postFix * postFix) - 1.0) + b);
+}
+pub fn circOut(t: f32, b: f32, c: f32, d: f32) f32 {
+    const postFix = t / d - 1.0;
+    return (c * math.sqrt(1.0 - postFix * postFix) + b);
+}
+pub fn circInOut(t: f32, b: f32, c: f32, d: f32) f32 {
+    var postFix = t / d;
+    if ((postFix / 2.0) < 1.0) return (-c / 2.0 * (math.sqrt(1.0 - postFix * postFix) - 1.0) + b);
+    postFix -= 2.0;
+    return (c / 2.0 * (math.sqrt(1.0 - postFix * postFix) + 1.0) + b);
+}
+
+// Cubic Easing functions
+pub fn cubicIn(t: f32, b: f32, c: f32, d: f32) f32 {
+    const postFix = t / d;
+    return (c * postFix * postFix * postFix + b);
+}
+pub fn cubicOut(t: f32, b: f32, c: f32, d: f32) f32 {
+    const postFix = t / d - 1.0;
+    return (c * (postFix * postFix * postFix + 1.0) + b);
+}
+pub fn cubicInOut(t: f32, b: f32, c: f32, d: f32) f32 {
+    const postFix = t / d;
+    if (postFix / 2.0 < 1.0) return (c / 2.0 * postFix * postFix * postFix + b);
+    postFix -= 2.0;
+    return (c / 2.0 * (t * t * t + 2.0) + b);
+}
+
+// Quadratic Easing functions
+pub fn quadIn(t: f32, b: f32, c: f32, d: f32) f32 {
+    const postfix = t / d;
+    return (c * postfix * postfix + b);
+}
+pub fn quadOut(t: f32, b: f32, c: f32, d: f32) f32 {
+    const postFix = t / d;
+    return (-c * postFix * (postFix - 2.0) + b);
+}
+pub fn quadInOut(t: f32, b: f32, c: f32, d: f32) f32 // Ease: Quadratic In Out
+{
+    const postFix = t / d;
+    return if (postFix / 2 < 1)
+        (((c / 2) * (postFix * postFix)) + b)
+    else
+        (-c / 2.0 * (((postFix - 1.0) * (postFix - 3.0)) - 1.0) + b);
+}
+
+// Exponential Easing functions
+pub fn expoIn(t: f32, b: f32, c: f32, d: f32) f32 {
+    return if (t == 0.0) b else (c * math.pow(f32, 2.0, 10.0 * (t / d - 1.0)) + b);
+}
+pub fn expoOut(t: f32, b: f32, c: f32, d: f32) f32 {
+    return if (t == d) (b + c) else (c * (-math.pow(f32, 2.0, -10.0 * t / d) + 1.0) + b);
+}
+pub fn expoInOut(t: f32, b: f32, c: f32, d: f32) f32 {
+    if (t == 0.0) return b;
+    if (t == d) return (b + c);
+    const postFix = t / d;
+    if ((postFix / 2.0) < 1.0) return (c / 2.0 * math.pow(f32, 2.0, 10.0 * (postFix - 1.0)) + b);
+
+    return (c / 2.0 * (-math.pow(f32, 2.0, -10.0 * (postFix - 1.0)) + 2.0) + b);
+}
+
+// Back Easing functions
+pub fn backIn(t: f32, b: f32, c: f32, d: f32) f32 {
+    const s = 1.70158;
+    const postFix = t / d;
+    return (c * (postFix) * postFix * ((s + 1.0) * postFix - s) + b);
+}
+
+pub fn backOut(t: f32, b: f32, c: f32, d: f32) f32 {
+    const s = 1.70158;
+    const postFix = t / d - 1.0;
+    return (c * (postFix * postFix * ((s + 1.0) * postFix + s) + 1.0) + b);
+}
+
+pub fn backInOut(t: f32, b: f32, c: f32, d: f32) f32 {
+    const s = 1.70158;
+    t /= d;
+    if (t / 2.0 < 1.0) {
+        s *= 1.525;
+        return (c / 2.0 * (t * t * ((s + 1.0) * t - s)) + b);
+    }
+    t -= 2;
+    const postFix = t;
+    s *= 1.525;
+    return (c / 2.0 * ((postFix) * t * ((s + 1.0) * t + s) + 2.0) + b);
+}
+
+// Bounce Easing functions
+
+pub fn bounceOut(t: f32, b: f32, c: f32, d: f32) f32 {
+    var tDivD = t / d;
+    if (tDivD < (1.0 / 2.75)) {
+        return (c * (7.5625 * tDivD * tDivD) + b);
+    } else if (tDivD < (2.0 / 2.75)) {
+        tDivD -= (1.5 / 2.75);
+        return (c * (7.5625 * tDivD * tDivD + 0.75) + b);
+    } else if (tDivD < (2.5 / 2.75)) {
+        tDivD -= (2.25 / 2.75);
+        return (c * (7.5625 * tDivD * tDivD + 0.9375) + b);
+    } else {
+        tDivD -= (2.625 / 2.75);
+        return (c * (7.5625 * tDivD * tDivD + 0.984375) + b);
+    }
+}
+
+pub fn bounceIn(t: f32, b: f32, c: f32, d: f32) f32 {
+    return (c - bounceOut(d - t, 0.0, c, d) + b);
+}
+
+pub fn bounceInOut(t: f32, b: f32, c: f32, d: f32) f32 {
+    if (t < d / 2.0) return (bounceIn(t * 2.0, 0.0, c, d) * 0.5 + b);
+    return (bounceOut(t * 2.0 - d, 0.0, c, d) * 0.5 + c * 0.5 + b);
+}
+
+// Elastic Easing functions
+pub fn elasticIn(t: f32, b: f32, c: f32, d: f32) f32 {
+    if (t == 0.0) return b;
+    var tDivD = t / d;
+    if (tDivD == 1.0) return (b + c);
+
+    const p = d * 0.3;
+    const a = c;
+    const s = p / 4.0;
+    tDivD -= 1;
+    const postFix = a * math.pow(f32, 2.0, 10.0 * tDivD);
+
+    return (-(postFix * math.sin((tDivD * d - s) * (2.0 * math.pi) / p)) + b);
+}
+
+pub fn elasticOut(t: f32, b: f32, c: f32, d: f32) f32 {
+    if (t == 0.0) return b;
+    const tDivD = t / d;
+    if (tDivD == 1.0) return (b + c);
+
+    const p = d * 0.3;
+    const a = c;
+    const s = p / 4.0;
+
+    return (a * math.pow(f32, 2.0, -10.0 * tDivD) * math.sin((tDivD * d - s) * (2.0 * math.pi) / p) + c + b);
+}
+
+pub fn elasticInOut(t: f32, b: f32, c: f32, d: f32) f32 {
+    if (t == 0.0) return b;
+    const tDivD = t / d;
+    if (tDivD / 2.0 == 2.0) return (b + c);
+
+    const p = d * (0.3 * 1.5);
+    const a = c;
+    const s = p / 4.0;
+
+    if (tDivD < 1.0) {
+        tDivD -= 1;
+        const postFix = a * math.pow(f32, 2.0, 10.0 * tDivD);
+        return -0.5 * (postFix * math.sin((tDivD * d - s) * (2.0 * math.pi) / p)) + b;
+    }
+
+    tDivD -= 1;
+    const postFix = a * math.pow(f32, 2.0, -10.0 * (tDivD));
+
+    return (postFix * math.sin((tDivD * d - s) * (2.0 * math.pi) / p) * 0.5 + c + b);
+}

--- a/examples/shapes/splines_drawing.zig
+++ b/examples/shapes/splines_drawing.zig
@@ -1,0 +1,226 @@
+const rl = @import("raylib");
+const rgui = @import("raygui");
+
+const MAX_SPLINE_POINTS = 32;
+const screenWidth = 800;
+const screenHeight = 450;
+
+// Cubic Bezier spline control points
+// NOTE: Every segment has two control points
+const ControlPoint = struct {
+    start: rl.Vector2,
+    end: rl.Vector2,
+};
+
+// Spline types
+const SplineType = enum(i32) {
+    linear = 0, // Linear
+    basis = 1, // B-Spline
+    catmullrom = 2, // Catmull-Rom
+    bezier = 3, // Cubic Bezier
+};
+
+//------------------------------------------------------------------------------------
+// Program main entry point
+//------------------------------------------------------------------------------------
+pub fn main() anyerror!void {
+    // Initialization
+    //--------------------------------------------------------------------------------------
+
+    rl.setConfigFlags(.{ .msaa_4x_hint = true });
+    rl.initWindow(screenWidth, screenHeight, "raylib [shapes] example - splines drawing");
+    defer rl.closeWindow(); // Close window and OpenGL context
+
+    var points: [MAX_SPLINE_POINTS]rl.Vector2 = undefined;
+    points[0] = rl.Vector2{ .x = 50.0, .y = 400.0 };
+    points[1] = rl.Vector2{ .x = 160.0, .y = 220.0 };
+    points[2] = rl.Vector2{ .x = 340.0, .y = 380.0 };
+    points[3] = rl.Vector2{ .x = 520.0, .y = 60.0 };
+    points[4] = rl.Vector2{ .x = 710.0, .y = 260.0 };
+    for (5..MAX_SPLINE_POINTS) |i| {
+        points[i] = rl.Vector2{ .x = 0, .y = 0 };
+    }
+
+    // Array required for spline bezier-cubic,
+    // including control points interleaved with start-end segment points
+    var pointsInterleaved: [3 * (MAX_SPLINE_POINTS - 1) + 1]rl.Vector2 = undefined;
+    for (&pointsInterleaved) |*point| {
+        point.* = rl.Vector2{ .x = 0, .y = 0 };
+    }
+
+    var pointCount: usize = 5;
+    var selectedPoint: ?*rl.Vector2 = null;
+    var focusedPoint: ?*rl.Vector2 = null;
+    var selectedControlPoint: ?*rl.Vector2 = null;
+    var focusedControlPoint: ?*rl.Vector2 = null;
+
+    // Cubic Bezier control points initialization
+    var control: [MAX_SPLINE_POINTS - 1]ControlPoint = undefined;
+    for (&control) |*cp| {
+        cp.* = .{ .end = .{ .x = 0, .y = 0 }, .start = .{ .x = 0, .y = 0 } };
+    }
+    for (0..pointCount) |i| {
+        control[i].start = .{ .x = points[i].x + 50, .y = points[i].y };
+        control[i].end = .{ .x = points[i + 1].x - 50, .y = points[i + 1].y };
+    }
+
+    // Spline config variables
+    var splineThickness: f32 = 8.0;
+    var splineTypeActive = SplineType.linear;
+    var splineTypeEditMode = false;
+    var splineHelpersActive = true;
+
+    rl.setTargetFPS(60); // Set our game to run at 60 frames-per-second
+    //--------------------------------------------------------------------------------------
+
+    // Main game loop
+    while (!rl.windowShouldClose()) // Detect window close button or ESC key
+    {
+        // Update
+        //----------------------------------------------------------------------------------
+        // Spline points creation logic (at the end of spline)
+        if (rl.isMouseButtonPressed(.right) and (pointCount < MAX_SPLINE_POINTS)) {
+            points[pointCount] = rl.getMousePosition();
+            const i = pointCount - 1;
+            control[i].start = rl.Vector2{ .x = points[i].x + 50, .y = points[i].y };
+            control[i].end = rl.Vector2{ .x = points[i + 1].x - 50, .y = points[i + 1].y };
+            pointCount += 1;
+        }
+
+        // Spline point focus and selection logic
+        if (selectedPoint == null and ((splineTypeActive != SplineType.bezier) or selectedControlPoint == null)) {
+            focusedPoint = null;
+            for (0..pointCount) |i| {
+                if (rl.checkCollisionPointCircle(rl.getMousePosition(), points[i], 8.0)) {
+                    focusedPoint = &points[i];
+                    break;
+                }
+            }
+            if (rl.isMouseButtonPressed(.left)) selectedPoint = focusedPoint;
+        }
+
+        // Spline point movement logic
+        if (selectedPoint) |point| {
+            point.* = rl.getMousePosition();
+            if (rl.isMouseButtonReleased(.left)) selectedPoint = null;
+        }
+
+        // Cubic Bezier spline control points logic
+        if ((splineTypeActive == SplineType.bezier) and focusedPoint == null) {
+            // Spline control point focus and selection logic
+            if (selectedControlPoint == null) {
+                focusedControlPoint = null;
+                for (0..pointCount) |i| {
+                    if (rl.checkCollisionPointCircle(rl.getMousePosition(), control[i].start, 6.0)) {
+                        focusedControlPoint = &control[i].start;
+                        break;
+                    } else if (rl.checkCollisionPointCircle(rl.getMousePosition(), control[i].end, 6.0)) {
+                        focusedControlPoint = &control[i].end;
+                        break;
+                    }
+                }
+                if (rl.isMouseButtonPressed(.left)) selectedControlPoint = focusedControlPoint;
+            }
+
+            // Spline control point movement logic
+            if (selectedControlPoint) |cp| {
+                cp.* = rl.getMousePosition();
+                if (rl.isMouseButtonReleased(.left)) selectedControlPoint = null;
+            }
+        }
+
+        // Spline selection logic
+        splineTypeActive = switch (rl.getKeyPressed()) {
+            .one => SplineType.linear,
+            .two => SplineType.basis,
+            .three => SplineType.catmullrom,
+            .four => SplineType.basis,
+            else => splineTypeActive,
+        };
+
+        // Clear selection when changing to a spline without control points
+        if (rl.isKeyPressed(.one) or rl.isKeyPressed(.two) or rl.isKeyPressed(.three)) selectedControlPoint = null;
+
+        //----------------------------------------------------------------------------------
+
+        // Draw
+        //----------------------------------------------------------------------------------
+        rl.beginDrawing();
+        defer rl.endDrawing();
+
+        rl.clearBackground(.ray_white);
+
+        switch (splineTypeActive) {
+            SplineType.linear => rl.drawSplineLinear(points[0..pointCount], splineThickness, .red),
+            SplineType.basis => rl.drawSplineBasis(points[0..pointCount], splineThickness, .red),
+            SplineType.catmullrom => rl.drawSplineCatmullRom(points[0..pointCount], splineThickness, .red),
+            SplineType.bezier => {
+                // NOTE: Cubic-bezier spline requires the 2 control points of each segnment to be
+                // provided interleaved with the start and end point of every segment
+                for (0..pointCount - 1) |i| {
+                    pointsInterleaved[3 * i] = points[i];
+                    pointsInterleaved[3 * i + 1] = control[i].start;
+                    pointsInterleaved[3 * i + 2] = control[i].end;
+                }
+
+                pointsInterleaved[3 * (pointCount - 1)] = points[pointCount - 1];
+
+                // Draw spline: cubic-bezier (with control points)
+                rl.drawSplineBezierCubic(pointsInterleaved[0 .. 3 * pointCount], splineThickness, .red);
+
+                // Draw spline control points
+                for (0..pointCount - 1) |i| {
+                    // Every cubic bezier point have two control points
+                    rl.drawCircleV(control[i].start, 6, .gold);
+                    rl.drawCircleV(control[i].end, 6, .gold);
+
+                    if (focusedControlPoint == &control[i].start) rl.drawCircleV(control[i].start, 8, .green) else if (focusedControlPoint == &control[i].end) rl.drawCircleV(control[i].end, 8, .green);
+                    rl.drawLineEx(points[i], control[i].start, 1.0, .light_gray);
+                    rl.drawLineEx(points[i + 1], control[i].end, 1.0, .light_gray);
+
+                    // Draw spline control lines
+                    rl.drawLineV(points[i], control[i].start, .gray);
+                    rl.drawLineV(control[i].end, points[i + 1], .gray);
+                }
+            },
+        }
+
+        if (splineHelpersActive) {
+            // Draw spline point helpers
+            for (0..pointCount) |i| {
+                const radius: f32 = if (focusedPoint == &points[i]) 12 else 8;
+                const color: rl.Color = if (focusedPoint == &points[i]) .blue else .dark_blue;
+                rl.drawCircleLinesV(points[i], radius, color);
+                if ((splineTypeActive != SplineType.linear) and
+                    (splineTypeActive != SplineType.bezier) and
+                    (i < pointCount - 1)) rl.drawLineV(points[i], points[i + 1], .gray);
+
+                rl.drawText(rl.textFormat("[%.0f, %.0f]", .{ points[i].x, points[i].y }), @intFromFloat(points[i].x), @intFromFloat(points[i].y + 10), 10, .black);
+            }
+        }
+
+        // Check all possible UI states that require controls lock
+        if (splineTypeEditMode or selectedPoint != null or selectedControlPoint != null) rgui.lock();
+
+        // Draw spline config
+        _ = rgui.label(.{ .x = 12, .y = 62, .width = 140, .height = 24 }, rl.textFormat("Spline thickness: %i", .{@as(i64, @intFromFloat(splineThickness))}));
+
+        _ = rgui.sliderBar(.{ .x = 12, .y = 60 + 24, .width = 140, .height = 16 }, "", "", &splineThickness, 1.0, 40.0);
+
+        _ = rgui.checkBox(.{ .x = 12, .y = 110, .width = 20, .height = 20 }, "Show point helpers", &splineHelpersActive);
+
+        if (splineTypeEditMode) rgui.unlock();
+
+        _ = rgui.label(.{ .x = 12, .y = 10, .width = 140, .height = 24 }, "Spline type:");
+        var active: i32 = @intFromEnum(splineTypeActive);
+        if (rgui.dropdownBox(.{
+            .x = 12,
+            .y = 8 + 24,
+            .width = 140,
+            .height = 28,
+        }, "LINEAR;BSPLINE;CATMULLROM;BEZIER", &active, splineTypeEditMode) > 0) splineTypeEditMode = !splineTypeEditMode;
+        splineTypeActive = @enumFromInt(active);
+
+        rgui.unlock();
+    }
+}

--- a/examples/shapes/top_down_lights.zig
+++ b/examples/shapes/top_down_lights.zig
@@ -1,0 +1,341 @@
+const rl = @import("raylib");
+const std = @import("std");
+
+// Custom Blend Modes
+const RLGL_SRC_ALPHA = 0x0302;
+const RLGL_MIN = 0x8007;
+const RLGL_MAX = 0x8008;
+
+const MAX_BOXES = 20;
+/// MAX_BOXES *3. Each box can cast up to two shadow volumes for the edges it is away from, and one for the box itself
+const MAX_SHADOWS = MAX_BOXES * 3;
+const MAX_LIGHTS = 16;
+
+// Shadow geometry type
+const ShadowGeometry = struct {
+    vertices: [4]rl.Vector2,
+};
+
+// Light info type
+const LightInfo = struct {
+    /// Is this light slot active?
+    active: bool,
+    /// Does this light need to be updated?
+    dirty: bool,
+    /// Is this light in a valid position?
+    valid: bool,
+
+    /// Light position
+    position: rl.Vector2,
+    /// Alpha mask for the light
+    mask: rl.RenderTexture,
+    /// The distance the light touches
+    outerRadius: f32,
+    /// A cached rectangle of the light bounds to help with culling
+    bounds: rl.Rectangle,
+
+    shadows: [MAX_SHADOWS]ShadowGeometry,
+    shadowCount: usize,
+};
+
+var lights: [MAX_LIGHTS]LightInfo = undefined;
+
+// Move a light and mark it as dirty so that we update it's mask next frame
+fn MoveLight(slot: usize, x: f32, y: f32) void {
+    lights[slot].dirty = true;
+    lights[slot].position.x = x;
+    lights[slot].position.y = y;
+
+    // update the cached bounds
+    lights[slot].bounds.x = x - lights[slot].outerRadius;
+    lights[slot].bounds.y = y - lights[slot].outerRadius;
+}
+
+// Compute a shadow volume for the edge
+// It takes the edge and projects it back by the light radius and turns it into a quad
+fn computeShadowVolumeForEdge(slot: usize, sp: rl.Vector2, ep: rl.Vector2) void {
+    if (lights[slot].shadowCount >= MAX_SHADOWS) return;
+
+    const extension = lights[slot].outerRadius * 2;
+
+    const spVector = rl.math.vector2Normalize(rl.math.vector2Subtract(sp, lights[slot].position));
+    const spProjection = rl.math.vector2Add(sp, rl.math.vector2Scale(spVector, extension));
+
+    const epVector = rl.math.vector2Normalize(rl.math.vector2Subtract(ep, lights[slot].position));
+    const epProjection = rl.math.vector2Add(ep, rl.math.vector2Scale(epVector, extension));
+
+    lights[slot].shadows[lights[slot].shadowCount].vertices[0] = sp;
+    lights[slot].shadows[lights[slot].shadowCount].vertices[1] = ep;
+    lights[slot].shadows[lights[slot].shadowCount].vertices[2] = epProjection;
+    lights[slot].shadows[lights[slot].shadowCount].vertices[3] = spProjection;
+
+    lights[slot].shadowCount += 1;
+}
+
+// Draw the light and shadows to the mask for a light
+fn drawLightMask(slot: usize) void {
+    // Use the light mask
+    rl.beginTextureMode(lights[slot].mask);
+    defer rl.endTextureMode();
+
+    rl.clearBackground(.white);
+
+    // Force the blend mode to only set the alpha of the destination
+    rl.gl.rlSetBlendFactors(RLGL_SRC_ALPHA, RLGL_SRC_ALPHA, RLGL_MIN);
+    rl.gl.rlSetBlendMode(@intFromEnum(rl.gl.rlBlendMode.rl_blend_custom));
+    // defer going back to normal blend mode
+    defer rl.gl.rlSetBlendMode(@intFromEnum(rl.gl.rlBlendMode.rl_blend_alpha));
+
+    // If we are valid, then draw the light radius to the alpha mask
+    if (lights[slot].valid) rl.drawCircleGradient(@intFromFloat(lights[slot].position.x), @intFromFloat(lights[slot].position.y), lights[slot].outerRadius, rl.colorAlpha(.white, 0), .white);
+
+    rl.gl.rlDrawRenderBatchActive();
+
+    // Cut out the shadows from the light radius by forcing the alpha to maximum
+    rl.gl.rlSetBlendMode(@intFromEnum(rl.gl.rlBlendMode.rl_blend_alpha));
+    rl.gl.rlSetBlendFactors(RLGL_SRC_ALPHA, RLGL_SRC_ALPHA, RLGL_MAX);
+    rl.gl.rlSetBlendMode(@intFromEnum(rl.gl.rlBlendMode.rl_blend_custom));
+
+    // Draw the shadows to the alpha mask
+    for (0..lights[slot].shadowCount) |i| {
+        rl.drawTriangleFan(&lights[slot].shadows[i].vertices, .white);
+    }
+
+    rl.gl.rlDrawRenderBatchActive();
+}
+
+// Setup a light
+fn setupLight(slot: usize, x: f32, y: f32, radius: f32) !void {
+    lights[slot].active = true;
+    lights[slot].valid = false; // The light must prove it is valid
+    lights[slot].mask = try rl.loadRenderTexture(rl.getScreenWidth(), rl.getScreenHeight());
+    lights[slot].outerRadius = radius;
+
+    lights[slot].bounds.width = radius * 2;
+    lights[slot].bounds.height = radius * 2;
+
+    MoveLight(slot, x, y);
+
+    // Force the render texture to have something in it
+    drawLightMask(slot);
+}
+
+// See if a light needs to update it's mask
+// fn UpdateLight(slot: usize, Rectangle* boxes, int count) bool
+fn updateLight(slot: usize, boxes: []rl.Rectangle) bool {
+    if (!lights[slot].active or !lights[slot].dirty) return false;
+
+    lights[slot].dirty = false;
+    lights[slot].shadowCount = 0;
+    lights[slot].valid = false;
+
+    for (boxes) |box| {
+        // Are we in a box? if so we are not valid
+        if (rl.checkCollisionPointRec(lights[slot].position, box)) return false;
+
+        // If this box is outside our bounds, we can skip it
+        if (!rl.checkCollisionRecs(lights[slot].bounds, box)) continue;
+
+        // Check the edges that are on the same side we are, and cast shadow volumes out from them
+
+        // Top
+        var sp = rl.Vector2{ .x = box.x, .y = box.y };
+        var ep = rl.Vector2{ .x = box.x + box.width, .y = box.y };
+
+        if (lights[slot].position.y > ep.y) computeShadowVolumeForEdge(slot, sp, ep);
+
+        // Right
+        sp = ep;
+        ep.y += box.height;
+        if (lights[slot].position.x < ep.x) computeShadowVolumeForEdge(slot, sp, ep);
+
+        // Bottom
+        sp = ep;
+        ep.x -= box.width;
+        if (lights[slot].position.y < ep.y) computeShadowVolumeForEdge(slot, sp, ep);
+
+        // Left
+        sp = ep;
+        ep.y -= box.height;
+        if (lights[slot].position.x > ep.x) computeShadowVolumeForEdge(slot, sp, ep);
+
+        // The box itself
+        lights[slot].shadows[lights[slot].shadowCount].vertices[0] = rl.Vector2{ .x = box.x, .y = box.y };
+        lights[slot].shadows[lights[slot].shadowCount].vertices[1] = rl.Vector2{ .x = box.x, .y = box.y + box.height };
+        lights[slot].shadows[lights[slot].shadowCount].vertices[2] = rl.Vector2{ .x = box.x + box.width, .y = box.y + box.height };
+        lights[slot].shadows[lights[slot].shadowCount].vertices[3] = rl.Vector2{ .x = box.x + box.width, .y = box.y };
+        lights[slot].shadowCount += 1;
+    }
+
+    lights[slot].valid = true;
+
+    drawLightMask(slot);
+
+    return true;
+}
+
+// Set up some boxes
+fn setupBoxes(boxes: []rl.Rectangle) void {
+    boxes[0] = rl.Rectangle{ .x = 150, .y = 80, .width = 40, .height = 40 };
+    boxes[1] = rl.Rectangle{ .x = 1200, .y = 700, .width = 40, .height = 40 };
+    boxes[2] = rl.Rectangle{ .x = 200, .y = 600, .width = 40, .height = 40 };
+    boxes[3] = rl.Rectangle{ .x = 1000, .y = 50, .width = 40, .height = 40 };
+    boxes[4] = rl.Rectangle{ .x = 500, .y = 350, .width = 40, .height = 40 };
+
+    for (5..boxes.len) |i| {
+        boxes[i] = rl.Rectangle{
+            .x = @floatFromInt(rl.getRandomValue(0, rl.getScreenWidth())),
+            .y = @floatFromInt(rl.getRandomValue(0, rl.getScreenHeight())),
+            .width = @floatFromInt(rl.getRandomValue(10, 100)),
+            .height = @floatFromInt(rl.getRandomValue(10, 100)),
+        };
+    }
+}
+
+//------------------------------------------------------------------------------------
+// Program main entry point
+//------------------------------------------------------------------------------------
+pub fn main() anyerror!void {
+    // Initialization
+    //--------------------------------------------------------------------------------------
+    const screenWidth = 800;
+    const screenHeight = 450;
+
+    rl.initWindow(screenWidth, screenHeight, "raylib [shapes] example - top down lights");
+    defer rl.closeWindow(); // Close window and OpenGL context
+
+    // Initialize our 'world' of boxes
+    var boxes: [MAX_BOXES]rl.Rectangle = undefined;
+    setupBoxes(&boxes);
+
+    // Create a checkerboard ground texture
+    const img = rl.genImageChecked(64, 64, 32, 32, .dark_brown, .dark_gray);
+    defer rl.unloadImage(img);
+    const backgroundTexture = try rl.loadTextureFromImage(img);
+    defer rl.unloadTexture(backgroundTexture);
+
+    // Create a global light mask to hold all the blended lights
+    const lightMask = try rl.loadRenderTexture(rl.getScreenWidth(), rl.getScreenHeight());
+    defer rl.unloadRenderTexture(lightMask);
+
+    // Setup initial light
+    try setupLight(0, 600, 400, 300);
+    defer {
+        //deinitialize light
+        for (&lights) |*light| {
+            if (light.active) rl.unloadRenderTexture(light.mask);
+        }
+    }
+    var nextLight: usize = 1;
+
+    var showLines = false;
+
+    rl.setTargetFPS(60); // Set our game to run at 60 frames-per-second
+    //--------------------------------------------------------------------------------------
+
+    // Main game loop
+    while (!rl.windowShouldClose()) // Detect window close button or ESC key
+    {
+        // Update
+        //----------------------------------------------------------------------------------
+        // Drag light 0
+        if (rl.isMouseButtonDown(.left)) MoveLight(0, rl.getMousePosition().x, rl.getMousePosition().y);
+
+        // Make a new light
+        if (rl.isMouseButtonPressed(.right) and (nextLight < MAX_LIGHTS)) {
+            try setupLight(nextLight, rl.getMousePosition().x, rl.getMousePosition().y, 200);
+            nextLight += 1;
+        }
+
+        // Toggle debug info
+        if (rl.isKeyPressed(.f1)) showLines = !showLines;
+
+        // Update the lights and keep track if any were dirty so we know if we need to update the master light mask
+        var dirtyLights = false;
+        for (0..MAX_LIGHTS) |i| {
+            if (updateLight(i, &boxes)) dirtyLights = true;
+        }
+
+        // Update the light mask
+        if (dirtyLights) {
+            // Build up the light mask
+            rl.beginTextureMode(lightMask);
+            defer rl.endTextureMode();
+
+            rl.clearBackground(.black);
+
+            // Force the blend mode to only set the alpha of the destination
+            rl.gl.rlSetBlendFactors(RLGL_SRC_ALPHA, RLGL_SRC_ALPHA, RLGL_MIN);
+            rl.gl.rlSetBlendMode(@intFromEnum(rl.gl.rlBlendMode.rl_blend_custom));
+            defer rl.gl.rlSetBlendMode(@intFromEnum(rl.gl.rlBlendMode.rl_blend_alpha));
+
+            // Merge in all the light masks
+            for (lights) |light| {
+                if (light.active) rl.drawTextureRec(light.mask.texture, rl.Rectangle{
+                    .x = 0,
+                    .y = 0,
+                    .width = @floatFromInt(rl.getScreenWidth()),
+                    .height = @floatFromInt(-rl.getScreenHeight()),
+                }, rl.Vector2.zero(), .white);
+            }
+
+            rl.gl.rlDrawRenderBatchActive();
+        }
+        //----------------------------------------------------------------------------------
+
+        // Draw
+        //----------------------------------------------------------------------------------
+        rl.beginDrawing();
+        defer rl.endDrawing();
+
+        rl.clearBackground(.black);
+
+        // Draw the tile background
+        rl.drawTextureRec(backgroundTexture, rl.Rectangle{
+            .x = 0,
+            .y = 0,
+            .width = @floatFromInt(rl.getScreenWidth()),
+            .height = @floatFromInt(rl.getScreenHeight()),
+        }, rl.Vector2.zero(), .white);
+
+        // Overlay the shadows from all the lights
+        rl.drawTextureRec(lightMask.texture, rl.Rectangle{
+            .x = 0,
+            .y = 0,
+            .width = @floatFromInt(rl.getScreenWidth()),
+            .height = @floatFromInt(-rl.getScreenHeight()),
+        }, rl.Vector2.zero(), rl.colorAlpha(.white, if (showLines) 0.75 else 1.0));
+
+        // Draw the lights
+        for (0..MAX_LIGHTS) |i| {
+            if (lights[i].active) rl.drawCircle(@intFromFloat(lights[i].position.x), @intFromFloat(lights[i].position.y), 10, if (i == 0) .yellow else .white);
+        }
+
+        if (showLines) {
+            for (0..lights[0].shadowCount) |s| {
+                rl.drawTriangleFan(&lights[0].shadows[s].vertices, .dark_purple);
+            }
+
+            for (boxes) |box| {
+                if (rl.checkCollisionRecs(box, lights[0].bounds)) rl.drawRectangleRec(box, .purple);
+
+                rl.drawRectangleLines(@intFromFloat(box.x), @intFromFloat(box.y), @intFromFloat(box.width), @intFromFloat(box.height), .dark_blue);
+            }
+
+            rl.drawText("(F1) Hide Shadow Volumes", 10, 50, 10, .green);
+        } else {
+            rl.drawText("(F1) Show Shadow Volumes", 10, 50, 10, .green);
+        }
+
+        rl.drawFPS(screenWidth - 80, 10);
+        rl.drawText("Drag to move light #1", 10, 10, 10, .dark_green);
+        rl.drawText("Right click to add new light", 10, 30, 10, .dark_green);
+        //----------------------------------------------------------------------------------
+    }
+
+    // De-Initialization
+    //--------------------------------------------------------------------------------------
+
+    //--------------------------------------------------------------------------------------
+
+}


### PR DESCRIPTION
takes a bite out of #200 and finishes all of the "shapes" examples. I followed the raylib examples more or less 1:1, with some minor tweaks to write more idomatic zig. These all look to mirror the examples on the website with the exception of top_down_lights. where on the website they don't render the checkerboard floor, but my example does. given the screenshot I think they have a bug and the zig rendering is correct