### PR TITLE
Zig 0.17

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -448,13 +448,13 @@ pub fn build(b: *std.Build) !void {
                 .settings = emcc_settings,
                 .shell_file_path = emsdk.shell(raylib_dep),
                 .install_dir = install_dir,
-                .embed_paths = &.{.{ .src_path = "resources/" }},
+                .embed_paths = &.{.{ .src_path = b.path("resources/") }},
+                .out_file_name = wasm.name,
             });
 
-            const html_filename = try std.fmt.allocPrint(b.allocator, "{s}.html", .{wasm.name});
             const emrun_step = emsdk.emrunStep(
                 b,
-                b.getInstallPath(install_dir, html_filename),
+                b.graph.path(.install_prefix, b.fmt("{s}.html", .{wasm.name})),
                 &.{},
             );
             emrun_step.dependOn(emcc_step);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .fingerprint = 0xc4cfa8c610114f28,
     .dependencies = .{
         .raylib = .{
-            .url = "git+https://github.com/raysan5/raylib#6.0",
-            .hash = "raylib-6.0.0-whq8uCSwLgWWeF3ec3dbG6Rr36SLFL-s2WJ1Q_2E22Bb",
+            .url = "git+https://github.com/miker2049/raylib?ref=zig-17#2039f928827c54db536d8e7cd201a9da55fa69e1",
+            .hash = "raylib-6.0.0-whq8uC93MAXS17kanWicN65EspW_qykGwkqsGt_nOvFh",
         },
         .raygui = .{
             .url = "git+https://github.com/raysan5/raygui#3b2855842ab578a034f827c38cf8f62c042fc983",
@@ -16,11 +16,11 @@
             .hash = "N-V-__8AAJl1DwBezhYo_VE6f53mPVm00R-Fk28NPW7P14EQ",
         },
         .zemscripten = .{
-            .url = "git+https://github.com/zig-gamedev/zemscripten#70bdafc473be2131445bb6fd977fe7cb92fd0f5f",
-            .hash = "zemscripten-0.2.0-dev-sRlDqEtQAAB_1tPdqJsxQIqXxvvklcFu6VN5p6ANy8hw",
+            .url = "git+https://github.com/Yinameah/zemscripten#06d49243789d638ba10d4af004c46df4da83579c",
+            .hash = "zemscripten-0.2.0-dev-sRlDqKFRAAAXl8aICu541O6PiY70v4HIr3FTmCg--WqM",
         },
     },
-    .minimum_zig_version = "0.16.0",
+    .minimum_zig_version = "0.17.0-dev.1158+1d1193aa7",
     .paths = .{
         "build.zig",
         "build.zig.zon",


### PR DESCRIPTION
Tentative/anticipatory branch for zig 0.17.

Probably do not want this merged yet, but these are the changes needed to build on nightly at the moment.  Only a few things needed!  Mostly needs to wait for [this](https://github.com/raysan5/raylib/pull/5951) and [this](https://github.com/zig-gamedev/zemscripten/pull/23).