### PR TITLE
Add missing shader uniform data types

### DIFF
--- a/lib/preludes/raylib-prelude.zig
+++ b/lib/preludes/raylib-prelude.zig
@@ -2031,7 +2031,11 @@ pub const ShaderUniformDataType = enum(c_int) {
     ivec2 = 5,
     ivec3 = 6,
     ivec4 = 7,
-    sampler2d = 8,
+    uint = 8,
+    uivec2 = 9,
+    uivec3 = 10,
+    uivec4 = 11,
+    sampler2d = 12,
 };
 
 pub const ShaderAttribute = enum(c_int) {

--- a/lib/raylib.zig
+++ b/lib/raylib.zig
@@ -2031,7 +2031,11 @@ pub const ShaderUniformDataType = enum(c_int) {
     ivec2 = 5,
     ivec3 = 6,
     ivec4 = 7,
-    sampler2d = 8,
+    uint = 8,
+    uivec2 = 9,
+    uivec3 = 10,
+    uivec4 = 11,
+    sampler2d = 12,
 };
 
 pub const ShaderAttribute = enum(c_int) {


### PR DESCRIPTION
Hi this is a simple PR to add missing Shader Uniform Data Types that I saw weren't in the current version of these bindings. This addresses the issue I opened recently #353

Let me know if you require additional changes to this PR.