### PR TITLE
Decrease stack usage to avoid stack overflow

### DIFF
--- a/examples/core/drop_files.zig
+++ b/examples/core/drop_files.zig
@@ -16,7 +16,12 @@ pub fn main() anyerror!void {
     defer rl.closeWindow(); // Close window and OpenGL context
 
     var filePathCounter: usize = 0;
-    var filePaths: [MAX_FILEPATH_RECORDED][MAX_FILEPATH_SIZE]u8 = std.mem.zeroes([MAX_FILEPATH_RECORDED][MAX_FILEPATH_SIZE]u8);
+    const allocator = std.heap.page_allocator;
+    var filePaths = try allocator.alloc([MAX_FILEPATH_SIZE]u8, MAX_FILEPATH_RECORDED);
+    defer allocator.free(filePaths);
+    for (filePaths) |*entry| {
+        entry.* = std.mem.zeroes([MAX_FILEPATH_SIZE]u8);
+    }
 
     rl.setTargetFPS(60);
 

--- a/examples/core/drop_files.zig
+++ b/examples/core/drop_files.zig
@@ -20,7 +20,7 @@ pub fn main() anyerror!void {
     var filePaths = try allocator.alloc([MAX_FILEPATH_SIZE]u8, MAX_FILEPATH_RECORDED);
     defer allocator.free(filePaths);
     for (filePaths) |*entry| {
-        entry.* = std.mem.zeroes([MAX_FILEPATH_SIZE]u8);
+        entry.* = @splat(0);
     }
 
     rl.setTargetFPS(60);


### PR DESCRIPTION
Running this example on Windows led to crash:
```
Stack overflow (no address available)
.. in win_probe_stack_only (compiler_rt.lib)
.. in ___chkstk_ms (compiler_rt.lib)
C:\raylib-zig\examples\core\drop_files.zig:9: 0x7ff7926a65da in main (drop_files_zcu.obj)
```
Allocating the filePaths array on the heap prevents the crash